### PR TITLE
Make pip requirements a file or url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,67 @@
-*.swp
+# Python
+*.py[cod]
+
+# C extensions
+*.so
+var
+sdist
+lib
+lib64
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+develop-eggs
+.installed.cfg
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+
+# Eclipse
+.project
+.pydevproject
+.pyproject
+.settings
+.metadata
+
+# Vim 
+.*.sw[a-z]
+*.un~
+Session.vim
+
+# Intellij
+.idea/
+DIRAC.iml
+
+# MaxOSX files
+.DS_Store
+
+# test stuff
+.pytest_cache
+.cache
 __pycache__
+pytests.xml
+nosetests.xml
+coverage.xml
+Local_*
+.hypothesis
+
+# docs
+# this is auto generated
+docs/source/CodeDocumentation/
+docs/_build

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ At the moment, there are no checks, but the program will crash.
 * `packages`: each packageGroup should have a list of packages
 * `patchDir`: directory where to look for the patches
 * `pipBuildDependencies`: list of rpm packages required to perform the pip install
-* `pipRequirements`: url to the requirements.txt file to feed pip
+* `pipRequirements`: url/path to the requirements.txt file to feed pip
 * `repo`: path to the repository where to copy the produced RPMs
 * `routineDir`: directory where to look for routines
 * `src`: The source of the package. Depending on what is passed here, the build procedure is slightly different. Currently, the src can either be the url of a SRPM, or the name of a fedora package.

--- a/README.md
+++ b/README.md
@@ -1,465 +1,54 @@
-# Principle
+# DIRACOS
 
-1. Create an empty repository
-2. Compile our own python and make an RPM out of it in this repository
-3. Rebuild all RPMs we need using this python
-4. Extract all the RPMs and the dependencies
-5. Install the python dependencies with pip
-6. Bundle everything as a tarball
+DIRACOS aims at bringing in one archive all the dependencies needed by DIRAC.
 
 
-CAUTION: if inside Docker, special care must be taken (https://github.com/rpm-software-management/mock/wiki#mock-inside-docker)
+- [ Principle](docs/0_concepts.md#principle)
+  * [ How it works](docs/0_concepts.md#how-it-works)
+    + [ Bootstrap issue](docs/0_concepts.md#bootstrap-issue)
+    + [ About EPEL repository](docs/0_concepts.md#about-epel-repository)
+- [ Building RPMs](docs/10_RPMs.md#building-rpms)
+  * [ Patching the sources](docs/10_RPMs.md#patching-the-sources)
+  * [ Altering the normal build workflow](docs/10_RPMs.md#altering-the-normal-build-workflow)
+  * [ Caching mechanism](docs/10_RPMs.md#caching-mechanism)
+  * [ Adding an RPM package](docs/10_RPMs.md#adding-an-rpm-package)
+- [ Python packages](docs/20_pythonPackages.md#python-packages)
+  * [ Adding a python package](docs/20_pythonPackages.md#adding-a-python-package)
+- [ Generate a new diracos](docs/30_generatingDIRACOS.md#generate-a-new-diracos)
+  * [ Initial setup](docs/30_generatingDIRACOS.md#initial-setup)
+  * [ Configuration files](docs/30_generatingDIRACOS.md#configuration-files)
+  * [ Building everything](docs/30_generatingDIRACOS.md#building-everything)
+  * [ Build the python modules](docs/30_generatingDIRACOS.md#build-the-python-modules)
+  * [ Bundle DIRACOS](docs/30_generatingDIRACOS.md#bundle-diracos)
+  * [ Get your bundle](docs/30_generatingDIRACOS.md#get-your-bundle)
+  * [ Test it !](docs/30_generatingDIRACOS.md#test-it-!)
+- [ Configuration Grammar](docs/40_grammar.md#configuration-grammar)
+  * [ rpmBuild section](docs/40_grammar.md#rpmbuild-section)
+    + [ Package and PackageGroup](docs/40_grammar.md#package-and-packagegroup)
+      + [ Mandatory parameters](docs/40_grammar.md#mandatory-parameters)
+      + [ Optional parameters](docs/40_grammar.md#optional-parameters)
+- [ Troubleshoot](docs/50_troubleshoot.md#troubleshoot)
+  * [ Error `Requires: python(abi) = 2.6`](docs/50_troubleshoot.md#error-requires-pythonabi-26)
+  * [ Build is failing for broken rpm dependencies](docs/50_troubleshoot.md#build-is-failing-for-broken-rpm-dependencies)
+  * [ Script fails for missing python module](docs/50_troubleshoot.md#script-fails-for-missing-python-module)
+  * [ Issue with rpath](docs/50_troubleshoot.md#issue-with-rpath)
+  * [ CentOS7](docs/50_troubleshoot.md#centos7)
+- [ Test DIRACOS as a User](docs/60_useDIRACOS.md#test-diracos-as-a-user)
+
+
+
+Note: summary generated with
 ```
-  docker run --privileged --cap-add=SYS_ADMIN -it cern/slc6-base bash
-```
-
-Carefull, some compilations are a bit violent, so disabling oom killer can be needed by adding to docker run :
-```
---oom-kill-disable=true
-```
-
-Also you need to make sure that your containers have enough free space (20G). Consider adding the following to the dockerd sysconfig file. However, note that it will impact ALL your containers
-
-```
---storage-opt dm.basesize=20G'
-```
-
-#  Building RPMs
-
-The build of RPMs relies on mock (https://github.com/rpm-software-management/mock/wiki). This allows to build everything in an isolated environment.
-
-The build is done starting from an SRPM package or from the fedora repo using fedpkg (https://pagure.io/fedpkg).
-
-
-Once the rpms are built, they are copied to the repository you specify in your config files. The list of RPMs copied can be filtered.
-Some RPMs can be required only for building purposes. When this is the case, these RPMs are not considered later on when creating the bundle.
-
-It is very important to understand that the building procedure is incremental. Packages are built in turn, and one package might likely depend on its predecessor. So starting by trying to build the last package from the list is bound to fail. This also means that if you are changing a package in the middle, you might want to rebuild all what comes after (so you might as well rebuild everything...).
-
-A final note on the graphic libraries. They are just too big, too complex, too plateform dependant to be shipped here. So it is assumed that if you require X, you will install it independantely in your system.
-
-## Patching the sources
-
-It might be that you want to patch the spec file or even the source code. Either to not compile something useless, either because the SRPM is broken (bloody glite). This can be automated by puting a patch file in the patch directory specified in the configuration, and named `<package>.patch`.
-
-The patch file should be generated:
-* either using `git diff` in the case of fedpkg.
-* or using `diff -u -r original patched`, where `original` is a folder containing the uncompressed SRPM before patching, and `patched` the same, but patched.
-
-## Altering the normal build workflow
-
-In case an RPM requires specific actions, these actions can be executed using `routines`. A routine is just a python file containing an `execute` method. All the configuration of the package is passed to this routine. There are three types of routines:
-* pre-routine: executed before the normal workflow
-* post-routine: executed after the normal workflow
-* routine: executed instead of the normal workflow
-
-The routine file has to be named `(post-|pre-)<package>.py`.
-
-In case of a full routine, the routine is responsible for everything, from building to updating the repository.
-
-## Caching mechanism
-
-In order to optimize the building mechanism, a caching mechanism is in place, which avoids rebuilding a package that is already built. While gaining speed, this might trick you as well by not rebuilding a package that maybe requires to be. The mechanism is very simple: everytime a package is built, the srpm is copied to the yum repository. When building a package, if the corresponding SRPM with the correct version is found in the yum repo, the built is skip. If you want to force a rebuild, remove the srpm from the repository, and update it (not needed, but cleaner).
-
-
-
-# Python packages
-
-The python packages are installed with pip inside a mock environment, using virtualenv. Running inside the mock environment ensures to use the lib packages needed from our repo.
-
-The python packages are installed from a requirement file, linked in the json configuration file (see `pipRequirements`). Adding a new python package is as simple as adding a line there.
-
-# Creating the bundle
-
-Once all the RPMs have been produced, we grab their dependencies and extract all this in a root. This looks like a complete filesystem root.
-The python modules are then compiled and added to this tree.
-The whole directory structure is tared.
-
-## Bootstrap issue
-
-There is a boostrap issue with mock: mock needs gdb which, when compiled with python support, needs python. The point is that we want to use pyton 2.7 (at the moment), which is different from the system python (2.6) used to compile gdb. Thus, to solve that, we need to:
-
-1. Compile python and put it in our repository
-2. Recompile gdb without python support, or with our python
-3. Use this gdb instead of the system one.
-
-## About EPEL repository
-
-We could very well rely on the EPEL repository to provide most of the dependencies. The issue there is that it is very difficult to know if we are not rebuilding some of the dependencies of a given RPM, in which case one needs to recompile it as well.
-In order to avoid such headache, we just exclude EPEL alltogether, and recompile it all.
-
-# Generate a new diracos
-
-
-The building procedure of a new diracos is completely automated. It requires that you have a few basic packages installed on your system, a few mock config files and a json file containing the list of packages you want. The grammar for this json file is described bellow.
-
-It must be run from an SLC6 machine (or container).
-
-## Initial setup
+# the pages are sorted thanks to the numbers in front
+for doc in $(find docs -type f | sort -n );
+do grep '^#' $doc | while read title;
+   do
+     # The text is the title, with an indentation level depending on the depth, with square brackets
+     linkText=$(echo $title | sed -E -e 's/#{4}(.*)/      + [\1]/g' -e 's/#{3}(.*)/    + [\1]/g' -e 's/#{2}(.*)/  * [\1]/g' -e 's/#{1}(.*)/- [\1]/g')
+     # The anchor is the title, all lowercase, without special char, with '-' instead of space
+     anchor=$(echo $title | tr '[A-Z]' '[a-z]' |   sed -E -e 's/#+ +//g' -e 's/ /-/g');
+     echo "$linkText($doc#$anchor)";
+   done;
+done
 
 ```
-   # Install the few tools needed
-   yum install -y mock rpm-build fedora-packager createrepo python-pip
-
-   # Create the basic structure of your yum repository
-   export DIRACOS_REPO=/diracos_repo
-   mkdir -p $DIRACOS_REPO/i386 $DIRACOS_REPO/i686 $DIRACOS_REPO/src $DIRACOS_REPO/noarch $DIRACOS_REPO/x86_64 $DIRACOS_REPO/bootstrap $DIRACOS_REPO/buildOnly
-
-   # Needed for speedup optimization
-   curl -o $DIRACOS_REPO/bootstrap/lbzip2-2.5-2.el6.x86_64.rpm -L http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/bootstrap/lbzip2-2.5-2.el6.x86_64.rpm
-   curl -o $DIRACOS_REPO/bootstrap/pigz-2.3.4-1.el6.x86_64.rpm -L http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/bootstrap/pigz-2.3.4-1.el6.x86_64.rpm
-
-   createrepo $DIRACOS_REPO  
-
-   # Install the diracos machinery (currently from github)
-   #pip install diracos
-   pip install git+https://github.com/DIRACGrid/DIRACOS.git
-
-   # Get the configuration files by cloning the same repo
-```
-
-
-
-WARNING: the path of the repository is also writen in the mock configuration files as well as in the json file you use to build the packages
-
-## Configuration files
-
-You have to make sure that all the paths from the mock configuration files as well as the json configuration files are consistent.
-
-For the mock configuration files, it is mostly the local repository that you have to check, it has to correspond to `DIRACOS_REPO`.
-
-For the json file, the paths of mock have to match what is in the mock configuration files, and so does the repo. The paths for patches and routines can be relative, so it should work straight out of the checkout
-
-These are all the places where the `DIRACOS_REPO` is referred:
-
-  * https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-build-diracos.cfg#L93
-  * https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-install-diracos.cfg#L9
-  * https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-install-diracos.cfg#L94
-  * https://github.com/DIRACGrid/DIRACOS/blob/master/config/diracos.json#L9
-
- If you do not change the above mentioned lines, you have to have `$DIRACOS_REPO=/diracos_repo`, otherwise the compilation will fail.
-
- Finally, you can optimize the build by specifying the number of processors you want to use in the mock config file https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-build-diracos.cfg#L9
-
-
-## Building everything
-
-
-First you build all the RPMs:
-
-```
-dos-build-all-rpms <jsonFile>
-```
-
-For example
-```
-dos-build-all-rpms /tmp/DIRACOS/config/diracos.json
-```
-
-if you want to build a single Package
-
-```
-dos-build-package <jsonFile> <packageName>
-```
-
-## Build the python modules
-
-Currently, there is a different mock file. It is basically the same but mount a few folder inside the chroot. Maybe eventually I can merge them in a single one.
-
-The following script
-
-```
-dos-build-python-modules <jsonFile>
-```
-## Bundle DIRACOS
-
-Just packages eveything in a single tar file:
-
-```
-dos-bundle <jsonFile>
-```
-
-For example
-
-```
-dos-bundle /tmp/DIRACOS/config/diracos.json
-```
-
-## Get your bundle
-
-
-Copy it from your mock root in /tmp (e.g. /var/lib/mock/epel-6-x86_64-install/root/tmp/diracos-1.0.0.tar.gz)
-
-## Test it !
-
-You can run this in any machine (tested on SLC6 & CC7), not necessarily the one from which you built.
-
-The current test consist in a python files that will try to import pretty much all the python modules used in DIRAC, and make sure they are taken from diracos directory.
-
-The test files (`testrc` and `testImports.py`) are in the repository that you checked out for the config, under tests/integrations.
-
-
-```
-# go in a temporary directory, and untar DIRACOS
-
-cd /tmp
-untar diracos-1.0.0.tar.gz
-
-# Enter a new shell (so in case of problem, you just logout)
-bash
-
-# Setup the DIRACOS environment variable
-export DIRACOS=/tmp/diracos
-
-# setup the environment (more or less how DIRAC will do)
-source $DIRACOS/diracosrc
-
-# run the test
-pytest test_import.py
-
-# exit the shell
-exit
-```
-
-
-# Adding a new package
-
-Note: if you are adding a python module, use pip ! Not the RPM version.
-
-## RPM package
-
-Whether you want to replace an existing package by a newer version or add a completely new one, it is better to try first by hand. The process goes as follow:
-
-1. Get your SRPM package
-2. Patch it if needed
-3. Build it
-
-To build the SRPM package:
-
-```
-mock -r <mockConfigFile> --rebuild <SRPMFile>
-```
-
-If you want to patch it, you need to extract it, modify it, regenerate the SRPM from it
-
-
-```
-mkdir <workdir>
-cd <workdir>
-rpm2cpio <originaSRPMFile> | cpio -dvim
-```
-
-Modify the spec or the sources
-
-```
-mock -r <mockConfigFile> --buildsrpm --spec <specFile> --sources <workdir>
-```
-
-In case the SRPM contains only a spec file and an archive, the command becomes
-
-```
-mock -r <mockConfigFile> --buildsrpm --spec <specFile> --sources <tarFile>
-```
-
-Once you are happy with the result, just add the package the the json configuration file. If you modified the SRPM, you need to generate a patch file called `<package>.patch`, and put it in your patch directory.
-
-If the package is meant to stay in DIRACOS, it should be uploaded to DIRACOS srpm repository: http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/SRPM/
-
-```
-diff -r -u <original> <patched>
-```
-
-where `<original>` contains the uncompressed original SRPM, and `<patched>` your modified version
-
-
-Common locations for packages include:
-
-  * EPEL https://dl.fedoraproject.org/pub/epel/6/SRPMS/Packages/
-  * Redhat http://ftp.redhat.com/pub/redhat/linux/enterprise/6Client/en/os/SRPMS/ (and parent folder)
-  * http://emisoft.web.cern.ch/emisoft/dist/EMI/3/sl6/SRPMS
-  * http://dmc-repo.web.cern.ch/dmc-repo/el6/x86_64/
-
-
-Note: For any middleware package, rather use the source repo (for example http://dmc-repo.web.cern.ch/d) than derived (like EPEL)
-
-
-
-## Python package
-
-As mentioned earlier, python packages are installed with `pip` from a requirement file linked in the json config file as `pipRequirements`.
-To add a python package, just add it in the requirement file. However, in order to be able to build it in the mock and virtualenv environment, some building dependencies might be necessary. If so, they should be added in `pipBuildDependencies`.
-
-# Configuration Grammar
-
-The json formated files is used to describe what packages to build, as well as the environment in which to build it.
-
-
-## rpmBuild section
-This part of the configuration is used to build the RPMs. It is the `rpmBuild` attribute at the root of the json file.
-
-The grammar is very flexible in the sense that no attribute is forbidden. The packages configuration is built by aggregating all the options as explained bellow, and each package is built in turn. There are however a few mandatory parameters.
-
-### Package and PackageGroup
-
-In order to simplify the configuration and make it more readable, the packages to build are organized in a sorted list (rpmBuild), grouped by "packageGroup". The complete package configuration will be the global configuration, on top of which we add the packageGroup configuration, on top of which we add the package specific configuration. For example:
-
-```
-{
-   "rpmBuild" :
-   {
-     "opt1" : 1,
-     "packageGroups" : [
-         {
-            "name" : "pkgGrp1",
-            "opt1" : 2,
-            "packages" : [
-                {
-                   "name" : "pkg1",
-                   "opt2" : "x"
-                },
-                {
-                   "name" : "pkg2",
-                   "opt1" : 3
-                }
-            ]  
-         }
-     ]
-  }
-}
-```
-
-This will give the following packages:
-
-```
-{
-   "name" : "pkg1",
-   "opt1" : 2,
-   "opt2" : "x"
-}
-{
-   "name" : "pkg2",
-   "opt1" : 3
-}
-```
-
-
-
-
-#### Mandatory parameters
-
-
-At the moment, there are no checks, but the program will crash.
-
-* `mockConfig`: mock configuration file to use for the build
-* `mockInstallConfig`: mock configuration file to use for the build of python module and packaging
-* `mockRoot`: root directory where mock will work. WARNING: this value is related to the configuration in mockConfig.
-* `mockInstallRoot`: root directory where mock will work. WARNING: this value is related to the configuration in mockConfig.
-* `name`: The name of the package. Should be unique (CAUTION: no check on that yet). It is only used internaly.
-* `packageGroups`: list of package groups. Must be there at the root of the json file.
-* `packages`: each packageGroup should have a list of packages
-* `patchDir`: directory where to look for the patches
-* `pipBuildDependencies`: list of rpm packages required to perform the pip install
-* `pipRequirements`: url/path to the requirements.txt file to feed pip
-* `repo`: path to the repository where to copy the produced RPMs
-* `routineDir`: directory where to look for routines
-* `src`: The source of the package. Depending on what is passed here, the build procedure is slightly different. Currently, the src can either be the url of a SRPM, or the name of a fedora package.
-* `version`: version of dirac os being built (just a tag...)
-
-
-
-#### Optional parameters
-
-* `branch`: usefull only when building fedpkg. This is the branch of the repo to build.
-* `buildOnly`: boolean. if True, the RPMs are put in a different folder of the repository and are not considered for installation (unless required as dependency)
-* `excludePatterns`: list of patterns against which the produced RPMs are matched. The RPMs matching any of these patterns are not copied to the repository. This is usefull to exclude for example doc or debuginfo RPMs straight after building them. Be careful that sometimes, the doc RPMs are required as dependencies...
-* `pkgList`: list of RPMs to copy once the build is done. All the others are not copied.
-* `workDir`: directory where the work will be done. Default to `/tmp`
-
-Any other options will be read and passed to the build functions. Usefull examples can be "comment", or any other options your routines may need.
-
-
-
-# Troubleshoot
-
-## Error `Requires: python(abi) = 2.6`
-
-If you see such an error, start by comparing the version of the complaining package with the one which is in the diracos_repo. If they do not match, then you need to update the version shipped with DIRACOS.
-
-
-The whole point of building so many RPMs is because we try to get ride of python2.6 in all the low level packages. If you see such a message, that means that one of the package you are building requires a dependency that we do not provide. And if that's the case, you might want to look at version change. For example::
-
-```
-Getting requirements for yum-3.2.29-81.el6.py27.usc4.src
- --> python-2.7.13-2.el6.x86_64
- --> gettext-0.17-18.el6.x86_64
- --> intltool-0.41.0-1.1.el6.noarch
- --> python-nose-0.10.4-3.1.el6.py27.usc4.noarch
- --> python-2.7.13-2.el6.x86_64
- --> rpm-python-4.8.0-59.el6.x86_64
- --> Already installed : rpm-4.8.0-59.el6.x86_64
- --> python-iniparse-0.3.1-2.1.el6.py27.usc4.noarch
- --> python-2.7.13-2.el6.x86_64
- --> python-urlgrabber-3.9.1-11.el6.py27.usc4.noarch
- --> yum-metadata-parser-1.1.2-16.el6.py27.usc4.x86_64
- --> pygpgme-0.1-18.20090824bzr68.el6.py27.usc4.x86_64
-Error: Package: rpm-python-4.8.0-59.el6.x86_64 (base)
-           Requires: libpython2.6.so.1.0()(64bit)
-Error: Package: rpm-python-4.8.0-59.el6.x86_64 (base)
-           Requires: python(abi) = 2.6
-           Installing: python-2.7.13-2.el6.x86_64 (local-py2.7)
-               python(abi) = 2.7
- You could try using --skip-broken to work around the problem
- You could try running: rpm -Va --nofiles --nodigest
- ```
-
- This stack trace is due to `rpm-python-4.8.0-59` being pulled from the `base` repo, despite we provide `rpm-python-4.8.0-55`. This is because some packages (`yum` in that case) has a loose dependency (no specific version ) on `rpm-python`, so it takes the latest. The solution is to update our version of `rpm-python`
-
-
-
-## Build is failing for broken rpm dependencies
-
-Sometimes, the build will fail, for some weird reasons. To start with, do not bother. Clean the mock cache, the mock work directory, and restart the build. It might just work
-
-## Script fails for missing python module
-
-When crashing, mock sometimes messes up the actual environment. Log out from the machine, come back, and try again.
-
-## Issue with rpath
-
-In the future, we might see issue with rpath
-
-```
-mock-chroot> sh-4.1# ldd /tmp/root/usr/lib64/python2.7/lib-dynload/pyexpat.so
-	linux-vdso.so.1 =>  (0x00007fff6afac000)
-	libexpat.so.1 => /tmp/root/lib64/libexpat.so.1 (0x00007fb9716ff000)
-	libpython2.7.so.1.0 => /usr/lib64/libpython2.7.so.1.0 (0x00007fb971321000)
-	libpthread.so.0 => /tmp/root/lib64/libpthread.so.0 (0x00007fb971104000)
-	libc.so.6 => /tmp/root/lib64/libc.so.6 (0x00007fb970d70000)
-	libdl.so.2 => /tmp/root/lib64/libdl.so.2 (0x00007fb970b6c000)
-	libutil.so.1 => /tmp/root/lib64/libutil.so.1 (0x00007fb970969000)
-	libm.so.6 => /tmp/root/lib64/libm.so.6 (0x00007fb9706e5000)
-	/lib64/ld-linux-x86-64.so.2 (0x00007fb971b33000)
-
-<mock-chroot> sh-4.1# readelf -d /tmp/root/usr/lib64/python2.7/lib-dynload/pyexpat.so  | grep RPAT
-    0x000000000000000f (RPATH)              Library rpath: [/usr/lib64]
-```
-
-A tool can remove them if needed:
-https://linux.die.net/man/1/chrpath
-
-## CentOS7
-
-Currently there is an issue with CentOS7.
-The python scripts have `/usr/bin/env` as shebang. However, `/usr/bin/env` requires `GLIBC_2.14` on CentOS7, which is not in the `libc` shipped here. The solution is probably to fix the postinstall script of DIRAC to not use the system `env`
-
-# Test DIRACOS as a User
-
-
-If you want to test DIRACOS in a DIRAC installation, it is enough to do the following:
-
-```
-  https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py
-  chmod +x dirac-install.py
-  ./dirac-install.py -r v6r20 --dirac-os --dirac-os-version=0.0.5
-```
-If you want to install it together with your extension, you will most probably have to copy the diracos tar files from `http://lhcbproject.web.cern.ch/lhcbproject/dist/Dirac_project/installSource/` to your own baseURL

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -684,7 +684,7 @@
    },
    "mockInstallConfig": "../mockConfigs/mock-install-diracos.cfg",
    "mockInstallRoot": "/var/lib/mock/epel-6-x86_64-install",
-   "pipRequirements": "https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/requirements.txt",
+   "pipRequirements": "requirements.txt",
    "pipBuildDependencies": [
       "libcurl-devel",
       "python-devel",

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,0 +1,37 @@
+# From repo
+git+https://:@gitlab.cern.ch:8443/fts/fts-rest.git#egg=fts3
+git+https://github.com/DIRACGrid/pyGSI.git#egg=GSI
+
+# From pypi
+autopep8==1.3.3
+certifi
+CMRESHandler>=1.0.0b4
+elasticsearch-dsl>=2.0.0
+funcsigs
+futures
+GitPython>=2.1.0
+matplotlib>=2.1.0
+mock>=1.0.1
+MySQL-python>=1.2.5
+jinja2
+ipython==5.3.0
+numpy>=1.10.1
+pexpect>=4.0.1
+psutil>=4.2.0
+Pygments>=1.5
+pylint>=1.6.5
+pyparsing>=2.0.6
+pytest>=2.8.5
+pytest-cov>=2.2.0
+python-coveralls
+pytz>=2015.7
+readline>=6.2.4
+requests>=2.9.1
+rst2pdf>=0.93
+simplejson>=3.8.1
+six>=1.10
+sqlalchemy>=1.0.9
+stomp.py>=3.1.5
+suds-jurko>=0.6
+hypothesis
+python-json-logger>=0.1.8

--- a/diracos/Conf.py
+++ b/diracos/Conf.py
@@ -4,11 +4,13 @@ Manages the configuration for diracos
 
 import json
 import os
+from urlparse import urlparse
 
 
 # Path that might be relative
 PATH_OPTIONS = ("mockInstallConfig",
                 "mockInstallRoot",
+                "pipRequirements",
                )
 PKG_PATH_OPTIONS = ("mockConfig",
                     "mockRoot",
@@ -35,7 +37,9 @@ def load(jsonFile):
 
     for opt in PATH_OPTIONS:
       if opt in fullConf:
-        fullConf[opt] = os.path.abspath(os.path.join(confDirectory, fullConf[opt]))
+        # If it is a URL, we do not touch, otherwise, make it an absolute path
+        if not urlparse(fullConf[opt]).scheme:
+          fullConf[opt] = os.path.abspath(os.path.join(confDirectory, fullConf[opt]))
 
     rpmBuildConf = fullConf['rpmBuild']
 

--- a/docs/0_concepts.md
+++ b/docs/0_concepts.md
@@ -1,0 +1,28 @@
+# Principle
+
+The idea of DIRACOS is to rebuild all what we need from the system, and ship it all together as a big tarfile. The structure looks like a complete root filesystem.
+
+1. Create an empty repository
+2. Compile our own python and make an RPM out of it in this repository
+3. Rebuild all RPMs we need using this python
+4. Extract all the RPMs and the dependencies
+5. Install the python dependencies with pip
+6. Bundle everything as a tarball
+
+
+## How it works
+
+This process relies mostly on Fedora `mock` (https://github.com/rpm-software-management/mock/wiki) to build RPMs and to create isolated environment. Python packages are installed using pip.
+
+### Bootstrap issue
+
+There is a boostrap issue with mock: mock needs gdb which, when compiled with python support, needs python. The point is that we want to use pyton 2.7 (at the moment), which is different from the system python (2.6) used to compile gdb. Thus, to solve that, we need to:
+
+1. Compile python and put it in our repository
+2. Recompile gdb without python support, or with our python
+3. Use this gdb instead of the system one.
+
+### About EPEL repository
+
+We could very well rely on the EPEL repository to provide most of the dependencies. The issue there is that it is very difficult to know if we are not rebuilding some of the dependencies of a given RPM, in which case one needs to recompile it as well.
+In order to avoid such headache, we just exclude EPEL alltogether, and recompile it all.

--- a/docs/10_RPMs.md
+++ b/docs/10_RPMs.md
@@ -1,0 +1,96 @@
+#  Building RPMs
+
+The build of RPMs relies on mock (https://github.com/rpm-software-management/mock/wiki). This allows to build everything in an isolated environment.
+
+The build is done starting from an SRPM package or from the fedora repo using fedpkg (https://pagure.io/fedpkg).
+
+
+Once the rpms are built, they are copied to the repository you specify in your config files. The list of RPMs copied can be filtered.
+Some RPMs can be required only for building purposes. When this is the case, these RPMs are not considered later on when creating the bundle.
+
+It is very important to understand that the building procedure is incremental. Packages are built in turn, and one package might likely depend on its predecessor. So starting by trying to build the last package from the list is bound to fail. This also means that if you are changing a package in the middle, you might want to rebuild all what comes after (so you might as well rebuild everything...).
+
+A final note on the graphic libraries. They are just too big, too complex, too plateform dependant to be shipped here. So it is assumed that if you require X, you will install it independantely in your system.
+
+## Patching the sources
+
+It might be that you want to patch the spec file or even the source code. Either to not compile something useless, either because the SRPM is broken (bloody glite). This can be automated by puting a patch file in the patch directory specified in the configuration, and named `<package>.patch`.
+
+The patch file should be generated:
+* either using `git diff` in the case of fedpkg.
+* or using `diff -u -r original patched`, where `original` is a folder containing the uncompressed SRPM before patching, and `patched` the same, but patched.
+
+## Altering the normal build workflow
+
+In case an RPM requires specific actions, these actions can be executed using `routines`. A routine is just a python file containing an `execute` method. All the configuration of the package is passed to this routine. There are three types of routines:
+* pre-routine: executed before the normal workflow
+* post-routine: executed after the normal workflow
+* routine: executed instead of the normal workflow
+
+The routine file has to be named `(post-|pre-)<package>.py`.
+
+In case of a full routine, the routine is responsible for everything, from building to updating the repository.
+
+## Caching mechanism
+
+In order to optimize the building mechanism, a caching mechanism is in place, which avoids rebuilding a package that is already built. While gaining speed, this might trick you as well by not rebuilding a package that maybe requires to be. The mechanism is very simple: everytime a package is built, the srpm is copied to the yum repository. When building a package, if the corresponding SRPM with the correct version is found in the yum repo, the built is skip. If you want to force a rebuild, remove the srpm from the repository, and update it (not needed, but cleaner).
+
+
+
+## Adding an RPM package
+
+Note: if you are adding a python module, use pip ! Not the RPM version.
+
+Whether you want to replace an existing package by a newer version or add a completely new one, it is better to try first by hand. The process goes as follow:
+
+1. Get your SRPM package
+2. Patch it if needed
+3. Build it
+
+To build the SRPM package:
+
+```
+mock -r <mockConfigFile> --rebuild <SRPMFile>
+```
+
+If you want to patch it, you need to extract it, modify it, regenerate the SRPM from it
+
+
+```
+mkdir <workdir>
+cd <workdir>
+rpm2cpio <originaSRPMFile> | cpio -dvim
+```
+
+Modify the spec or the sources
+
+```
+mock -r <mockConfigFile> --buildsrpm --spec <specFile> --sources <workdir>
+```
+
+In case the SRPM contains only a spec file and an archive, the command becomes
+
+```
+mock -r <mockConfigFile> --buildsrpm --spec <specFile> --sources <tarFile>
+```
+
+Once you are happy with the result, just add the package the the json configuration file. If you modified the SRPM, you need to generate a patch file called `<package>.patch`, and put it in your patch directory.
+
+If the package is meant to stay in DIRACOS, it should be uploaded to DIRACOS srpm repository: http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/SRPM/
+
+```
+diff -r -u <original> <patched>
+```
+
+where `<original>` contains the uncompressed original SRPM, and `<patched>` your modified version
+
+
+Common locations for packages include:
+
+  * EPEL https://dl.fedoraproject.org/pub/epel/6/SRPMS/Packages/
+  * Redhat http://ftp.redhat.com/pub/redhat/linux/enterprise/6Client/en/os/SRPMS/ (and parent folder)
+  * http://emisoft.web.cern.ch/emisoft/dist/EMI/3/sl6/SRPMS
+  * http://dmc-repo.web.cern.ch/dmc-repo/el6/x86_64/
+
+
+Note: For any middleware package, rather use the source repo (for example http://dmc-repo.web.cern.ch/d) than derived (like EPEL)

--- a/docs/20_pythonPackages.md
+++ b/docs/20_pythonPackages.md
@@ -1,0 +1,11 @@
+# Python packages
+
+The python packages are installed with pip inside a mock environment, using virtualenv. Running inside the mock environment ensures to use the lib packages needed from our repo.
+
+The python packages are installed from a requirement file, linked in the json configuration file (see `pipRequirements`). Adding a new python package is as simple as adding a line there.
+
+
+## Adding a python package
+
+As mentioned earlier, python packages are installed with `pip` from a requirement file linked in the json config file as `pipRequirements`.
+To add a python package, just add it in the requirement file. However, in order to be able to build it in the mock and virtualenv environment, some building dependencies might be necessary. If so, they should be added in `pipBuildDependencies`.

--- a/docs/30_generatingDIRACOS.md
+++ b/docs/30_generatingDIRACOS.md
@@ -1,0 +1,149 @@
+# Generate a new diracos
+
+
+The building procedure of a new diracos is completely automated. It requires that you have a few basic packages installed on your system, a few mock config files and a json file containing the list of packages you want. The grammar for this json file is described bellow.
+
+It must be run from an SLC6 machine (or container).
+
+
+CAUTION: if inside Docker, special care must be taken (https://github.com/rpm-software-management/mock/wiki#mock-inside-docker)
+```
+  docker run --privileged --cap-add=SYS_ADMIN -it cern/slc6-base bash
+```
+
+Carefull, some compilations are a bit violent, so disabling oom killer can be needed by adding to docker run :
+```
+--oom-kill-disable=true
+```
+
+Also you need to make sure that your containers have enough free space (20G). Consider adding the following to the dockerd sysconfig file. However, note that it will impact ALL your containers
+
+```
+--storage-opt dm.basesize=20G'
+```
+
+## Initial setup
+
+```
+   # Install the few tools needed
+   yum install -y mock rpm-build fedora-packager createrepo python-pip
+
+   # Create the basic structure of your yum repository
+   export DIRACOS_REPO=/diracos_repo
+   mkdir -p $DIRACOS_REPO/i386 $DIRACOS_REPO/i686 $DIRACOS_REPO/src $DIRACOS_REPO/noarch $DIRACOS_REPO/x86_64 $DIRACOS_REPO/bootstrap $DIRACOS_REPO/buildOnly
+
+   # Needed for speedup optimization
+   curl -o $DIRACOS_REPO/bootstrap/lbzip2-2.5-2.el6.x86_64.rpm -L http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/bootstrap/lbzip2-2.5-2.el6.x86_64.rpm
+   curl -o $DIRACOS_REPO/bootstrap/pigz-2.3.4-1.el6.x86_64.rpm -L http://lhcb-rpm.web.cern.ch/lhcb-rpm/dirac/DIRACOS/bootstrap/pigz-2.3.4-1.el6.x86_64.rpm
+
+   createrepo $DIRACOS_REPO  
+
+   # Install the diracos machinery (currently from github)
+   #pip install diracos
+   pip install git+https://github.com/DIRACGrid/DIRACOS.git
+
+   # Get the configuration files by cloning the same repo
+```
+
+
+
+WARNING: the path of the repository is also writen in the mock configuration files as well as in the json file you use to build the packages
+
+## Configuration files
+
+You have to make sure that all the paths from the mock configuration files as well as the json configuration files are consistent.
+
+For the mock configuration files, it is mostly the local repository that you have to check, it has to correspond to `DIRACOS_REPO`.
+
+For the json file, the paths of mock have to match what is in the mock configuration files, and so does the repo. The paths for patches and routines can be relative, so it should work straight out of the checkout
+
+These are all the places where the `DIRACOS_REPO` is referred:
+
+  * https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-build-diracos.cfg#L93
+  * https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-install-diracos.cfg#L9
+  * https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-install-diracos.cfg#L94
+  * https://github.com/DIRACGrid/DIRACOS/blob/master/config/diracos.json#L9
+
+ If you do not change the above mentioned lines, you have to have `$DIRACOS_REPO=/diracos_repo`, otherwise the compilation will fail.
+
+ Finally, you can optimize the build by specifying the number of processors you want to use in the mock config file https://github.com/DIRACGrid/DIRACOS/blob/master/mockConfigs/mock-build-diracos.cfg#L9
+
+
+## Building everything
+
+
+First you build all the RPMs:
+
+```
+dos-build-all-rpms <jsonFile>
+```
+
+For example
+```
+dos-build-all-rpms /tmp/DIRACOS/config/diracos.json
+```
+
+if you want to build a single Package
+
+```
+dos-build-package <jsonFile> <packageName>
+```
+
+## Build the python modules
+
+Currently, there is a different mock file. It is basically the same but mount a few folder inside the chroot. Maybe eventually I can merge them in a single one.
+
+The following script
+
+```
+dos-build-python-modules <jsonFile>
+```
+## Bundle DIRACOS
+
+Just packages eveything in a single tar file:
+
+```
+dos-bundle <jsonFile>
+```
+
+For example
+
+```
+dos-bundle /tmp/DIRACOS/config/diracos.json
+```
+
+## Get your bundle
+
+
+Copy it from your mock root in /tmp (e.g. /var/lib/mock/epel-6-x86_64-install/root/tmp/diracos-1.0.0.tar.gz)
+
+## Test it !
+
+You can run this in any machine (tested on SLC6 & CC7), not necessarily the one from which you built.
+
+The current test consist in a python files that will try to import pretty much all the python modules used in DIRAC, and make sure they are taken from diracos directory.
+
+The test files (`testrc` and `testImports.py`) are in the repository that you checked out for the config, under tests/integrations.
+
+
+```
+   # go in a temporary directory, and untar DIRACOS
+
+   cd /tmp
+   untar diracos-1.0.0.tar.gz
+
+   # Enter a new shell (so in case of problem, you just logout)
+   bash
+
+   # Setup the DIRACOS environment variable
+   export DIRACOS=/tmp/diracos
+
+   # setup the environment (more or less how DIRAC will do)
+   source $DIRACOS/diracosrc
+
+   # run the test
+   pytest test_import.py
+
+   # exit the shell
+   exit
+```

--- a/docs/40_grammar.md
+++ b/docs/40_grammar.md
@@ -1,0 +1,88 @@
+
+# Configuration Grammar
+
+The json formated files is used to describe what packages to build, as well as the environment in which to build it.
+
+
+## rpmBuild section
+This part of the configuration is used to build the RPMs. It is the `rpmBuild` attribute at the root of the json file.
+
+The grammar is very flexible in the sense that no attribute is forbidden. The packages configuration is built by aggregating all the options as explained bellow, and each package is built in turn. There are however a few mandatory parameters.
+
+### Package and PackageGroup
+
+In order to simplify the configuration and make it more readable, the packages to build are organized in a sorted list (rpmBuild), grouped by "packageGroup". The complete package configuration will be the global configuration, on top of which we add the packageGroup configuration, on top of which we add the package specific configuration. For example:
+
+```
+{
+   "rpmBuild" :
+   {
+     "opt1" : 1,
+     "packageGroups" : [
+         {
+            "name" : "pkgGrp1",
+            "opt1" : 2,
+            "packages" : [
+                {
+                   "name" : "pkg1",
+                   "opt2" : "x"
+                },
+                {
+                   "name" : "pkg2",
+                   "opt1" : 3
+                }
+            ]  
+         }
+     ]
+  }
+}
+```
+
+This will give the following packages:
+
+```
+{
+   "name" : "pkg1",
+   "opt1" : 2,
+   "opt2" : "x"
+}
+{
+   "name" : "pkg2",
+   "opt1" : 3
+}
+```
+
+
+
+
+#### Mandatory parameters
+
+
+At the moment, there are no checks, but the program will crash.
+
+* `mockConfig`: mock configuration file to use for the build
+* `mockInstallConfig`: mock configuration file to use for the build of python module and packaging
+* `mockRoot`: root directory where mock will work. WARNING: this value is related to the configuration in mockConfig.
+* `mockInstallRoot`: root directory where mock will work. WARNING: this value is related to the configuration in mockConfig.
+* `name`: The name of the package. Should be unique (CAUTION: no check on that yet). It is only used internaly.
+* `packageGroups`: list of package groups. Must be there at the root of the json file.
+* `packages`: each packageGroup should have a list of packages
+* `patchDir`: directory where to look for the patches
+* `pipBuildDependencies`: list of rpm packages required to perform the pip install
+* `pipRequirements`: url/path to the requirements.txt file to feed pip
+* `repo`: path to the repository where to copy the produced RPMs
+* `routineDir`: directory where to look for routines
+* `src`: The source of the package. Depending on what is passed here, the build procedure is slightly different. Currently, the src can either be the url of a SRPM, or the name of a fedora package.
+* `version`: version of dirac os being built (just a tag...)
+
+
+
+#### Optional parameters
+
+* `branch`: usefull only when building fedpkg. This is the branch of the repo to build.
+* `buildOnly`: boolean. if True, the RPMs are put in a different folder of the repository and are not considered for installation (unless required as dependency)
+* `excludePatterns`: list of patterns against which the produced RPMs are matched. The RPMs matching any of these patterns are not copied to the repository. This is usefull to exclude for example doc or debuginfo RPMs straight after building them. Be careful that sometimes, the doc RPMs are required as dependencies...
+* `pkgList`: list of RPMs to copy once the build is done. All the others are not copied.
+* `workDir`: directory where the work will be done. Default to `/tmp`
+
+Any other options will be read and passed to the build functions. Usefull examples can be "comment", or any other options your routines may need.

--- a/docs/50_troubleshoot.md
+++ b/docs/50_troubleshoot.md
@@ -1,0 +1,72 @@
+# Troubleshoot
+
+## Error `Requires: python(abi) = 2.6`
+
+If you see such an error, start by comparing the version of the complaining package with the one which is in the diracos_repo. If they do not match, then you need to update the version shipped with DIRACOS.
+
+
+The whole point of building so many RPMs is because we try to get ride of python2.6 in all the low level packages. If you see such a message, that means that one of the package you are building requires a dependency that we do not provide. And if that's the case, you might want to look at version change. For example::
+
+```
+Getting requirements for yum-3.2.29-81.el6.py27.usc4.src
+ --> python-2.7.13-2.el6.x86_64
+ --> gettext-0.17-18.el6.x86_64
+ --> intltool-0.41.0-1.1.el6.noarch
+ --> python-nose-0.10.4-3.1.el6.py27.usc4.noarch
+ --> python-2.7.13-2.el6.x86_64
+ --> rpm-python-4.8.0-59.el6.x86_64
+ --> Already installed : rpm-4.8.0-59.el6.x86_64
+ --> python-iniparse-0.3.1-2.1.el6.py27.usc4.noarch
+ --> python-2.7.13-2.el6.x86_64
+ --> python-urlgrabber-3.9.1-11.el6.py27.usc4.noarch
+ --> yum-metadata-parser-1.1.2-16.el6.py27.usc4.x86_64
+ --> pygpgme-0.1-18.20090824bzr68.el6.py27.usc4.x86_64
+Error: Package: rpm-python-4.8.0-59.el6.x86_64 (base)
+           Requires: libpython2.6.so.1.0()(64bit)
+Error: Package: rpm-python-4.8.0-59.el6.x86_64 (base)
+           Requires: python(abi) = 2.6
+           Installing: python-2.7.13-2.el6.x86_64 (local-py2.7)
+               python(abi) = 2.7
+ You could try using --skip-broken to work around the problem
+ You could try running: rpm -Va --nofiles --nodigest
+ ```
+
+ This stack trace is due to `rpm-python-4.8.0-59` being pulled from the `base` repo, despite we provide `rpm-python-4.8.0-55`. This is because some packages (`yum` in that case) has a loose dependency (no specific version ) on `rpm-python`, so it takes the latest. The solution is to update our version of `rpm-python`
+
+
+
+## Build is failing for broken rpm dependencies
+
+Sometimes, the build will fail, for some weird reasons. To start with, do not bother. Clean the mock cache, the mock work directory, and restart the build. It might just work
+
+## Script fails for missing python module
+
+When crashing, mock sometimes messes up the actual environment. Log out from the machine, come back, and try again.
+
+## Issue with rpath
+
+In the future, we might see issue with rpath
+
+```
+mock-chroot> sh-4.1# ldd /tmp/root/usr/lib64/python2.7/lib-dynload/pyexpat.so
+	linux-vdso.so.1 =>  (0x00007fff6afac000)
+	libexpat.so.1 => /tmp/root/lib64/libexpat.so.1 (0x00007fb9716ff000)
+	libpython2.7.so.1.0 => /usr/lib64/libpython2.7.so.1.0 (0x00007fb971321000)
+	libpthread.so.0 => /tmp/root/lib64/libpthread.so.0 (0x00007fb971104000)
+	libc.so.6 => /tmp/root/lib64/libc.so.6 (0x00007fb970d70000)
+	libdl.so.2 => /tmp/root/lib64/libdl.so.2 (0x00007fb970b6c000)
+	libutil.so.1 => /tmp/root/lib64/libutil.so.1 (0x00007fb970969000)
+	libm.so.6 => /tmp/root/lib64/libm.so.6 (0x00007fb9706e5000)
+	/lib64/ld-linux-x86-64.so.2 (0x00007fb971b33000)
+
+<mock-chroot> sh-4.1# readelf -d /tmp/root/usr/lib64/python2.7/lib-dynload/pyexpat.so  | grep RPAT
+    0x000000000000000f (RPATH)              Library rpath: [/usr/lib64]
+```
+
+A tool can remove them if needed:
+https://linux.die.net/man/1/chrpath
+
+## CentOS7
+
+Currently there is an issue with CentOS7.
+The python scripts have `/usr/bin/env` as shebang. However, `/usr/bin/env` requires `GLIBC_2.14` on CentOS7, which is not in the `libc` shipped here. The solution is probably to fix the postinstall script of DIRAC to not use the system `env`

--- a/docs/60_useDIRACOS.md
+++ b/docs/60_useDIRACOS.md
@@ -1,0 +1,11 @@
+# Test DIRACOS as a User
+
+
+If you want to test DIRACOS in a DIRAC installation, it is enough to do the following:
+
+```
+  https://raw.githubusercontent.com/DIRACGrid/DIRAC/integration/Core/scripts/dirac-install.py
+  chmod +x dirac-install.py
+  ./dirac-install.py -r v6r20 --dirac-os --dirac-os-version=0.0.5
+```
+If you want to install it together with your extension, you will most probably have to copy the diracos tar files from `http://lhcbproject.web.cern.ch/lhcbproject/dist/Dirac_project/installSource/` to your own baseURL

--- a/scripts/fixPipRequirementsVersions.py
+++ b/scripts/fixPipRequirementsVersions.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+import sys
+import json
+from diracos import Conf, diracoslib
+import logging
+import pprint
+
+
+def main():
+  logging.basicConfig(level=logging.DEBUG)
+  jsonConf = sys.argv[1]
+
+  cfg = Conf.load(jsonConf)
+  #pprint.pprint(allPackages)
+
+  mockInstallConfig = cfg['mockInstallConfig']
+  mockInstallRoot = cfg['mockInstallRoot']
+  pipRequirements=  cfg['pipRequirements']
+
+
+  fixedVersionFile = diracoslib.fixPipRequirementsVersions(mockInstallConfig, mockInstallRoot, pipRequirements)
+  print "Fixed version file in %s"%fixedVersionFile
+
+if __name__ == '__main__':
+  main()

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,13 @@ setup(
     url='https://github.com/DIRACGrid/DIRACOS',
     license='GPLv3',
     entry_points={
-        'console_scripts': ['dos-build-python-modules=scripts.buildPythonModules:main',
-                            'dos-bundle=scripts.bundleDiracOS:main',
-                            'dos-build-all-rpms=scripts.buildAll:main',
+        'console_scripts': ['dos-build-all-rpms=scripts.buildAll:main',
                             'dos-build-package=scripts.buildPackage:main',
-                            'dos-dump-config=scripts.dumpConfig:main', ],
+                            'dos-build-python-modules=scripts.buildPythonModules:main',
+                            'dos-bundle=scripts.bundleDiracOS:main',
+                            'dos-dump-config=scripts.dumpConfig:main',
+                            'dos-fix-pip-versions=scripts.fixPipRequirementsVersions:main'
+                             ],
     },
     packages=find_packages()
 )

--- a/tests/testFiles/config_test.json
+++ b/tests/testFiles/config_test.json
@@ -14,7 +14,7 @@
                   "name" : "grp1_pkg1_name",
                   "routine": "grp1_pkg1_routine",
                   "src": "grp1_pkg1_src",
-                  "mockConfig": "grp1_pkg1_mockConfig",
+                  "mockConfig": "grp1_pkg1_mockConfig.cfg",
                   "mockRoot": "grp1_pkg1_mockRoot",
                   "patchDir" : "grp1_pkg1_patchDir",
                   "patchFile" : "grp1_pkg1_patchFile",

--- a/tests/testFiles/pip_req_file.json
+++ b/tests/testFiles/pip_req_file.json
@@ -1,0 +1,20 @@
+{
+   "rpmBuild" :{
+      "mockConfig": "mockConfig",
+      "mockRoot": "mockRoot",
+      "patchDir" : "patchDir",
+      "packageGroups": [
+         {
+            "name": "grp1",
+            "packages": [
+               {
+                  "name" : "grp1_pkg1_name",
+                  "src": "grp1_pkg1_src"
+               }
+            ]
+         }
+      ],
+      "repo": "repo"
+   },
+   "pipRequirements" : "../requirements.txt"
+}

--- a/tests/testFiles/pip_req_url.json
+++ b/tests/testFiles/pip_req_url.json
@@ -1,0 +1,20 @@
+{
+   "rpmBuild" :{
+      "mockConfig": "mockConfig",
+      "mockRoot": "mockRoot",
+      "patchDir" : "patchDir",
+      "packageGroups": [
+         {
+            "name": "grp1",
+            "packages": [
+               {
+                  "name" : "grp1_pkg1_name",
+                  "src": "grp1_pkg1_src"
+               }
+            ]
+         }
+      ],
+      "repo": "repo"
+   },
+   "pipRequirements" : "https://aURL.com/requirements.txt"
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,79 +3,82 @@ import os
 
 from context import diracos
 from diracos import Conf
-json_test_file = os.path.join(os.path.dirname(__file__), 'config_test.json')
 
-cfg = Conf.load(json_test_file)
 
-# def test_global_config_objects():
-#   """ Checks that the configuration file is correctly read"""
-#
-#   for attr in ['mockConfig', 'mockRoot', 'patchDir', 'repo']:
-#     assert getattr(cfg, attr) == attr
-#
-#   pkgGrp1 = cfg.packageGroups[0]
-#   assert pkgGrp1.name == 'grp1'
-#   for attr in ['mockConfig', 'mockRoot', 'patchDir', 'repo']:
-#     assert getattr(pkgGrp1, attr) == 'grp1_%s'%attr
-#
-#   grp1Pkg1 = pkgGrp1.packages[0]
-#   for attr in ['name', 'routine', 'src', 'mockConfig', 'mockRoot', 'patchDir', 'patchFile', 'repo']:
-#     assert getattr(grp1Pkg1, attr) == 'grp1_pkg1_%s'%attr
-#   for attr in ['buildOnly', 'disablePatch']:
-#     assert getattr(grp1Pkg1, attr) is True
-#
-#   grp1Pkg2 = pkgGrp1.packages[1]
-#   for attr in ['routine', 'mockConfig', 'mockRoot', 'patchDir', 'patchFile', 'repo']:
-#     assert getattr(grp1Pkg2, attr) is None
-#   for attr in ['name', 'src', ]:
-#     assert getattr(grp1Pkg2, attr) == 'grp1_pkg2_%s'%attr
-#   for attr in ['buildOnly', 'disablePatch']:
-#     assert getattr(grp1Pkg2, attr) is False
-#
-#
-#
-#   # No specification in grp2, so it should all be None
-#   pkgGrp2 = cfg.packageGroups[1]
-#   assert pkgGrp2.name == 'grp2'
-#   for attr in ['mockConfig', 'mockRoot', 'patchDir', 'repo']:
-#     assert getattr(pkgGrp2, attr) is None
-#
-#   grp2Pkg1 = pkgGrp2.packages[0]
-#   for attr in ['name', 'src', 'mockConfig', 'mockRoot', 'patchDir', 'patchFile']:
-#     assert getattr(grp2Pkg1, attr) == 'grp2_pkg1_%s'%attr
-#   for attr in ['routine', 'repo']:
-#     assert getattr(grp2Pkg1, attr) is None
-#   for attr in ['buildOnly', 'disablePatch']:
-#     assert getattr(grp2Pkg1, attr) is True
-#
-#   grp2Pkg2 = pkgGrp2.packages[1]
-#   for attr in ['routine', 'mockConfig', 'mockRoot', 'patchDir', 'patchFile', 'repo']:
-#     assert getattr(grp2Pkg2, attr) is None
-#   for attr in ['name', 'src', ]:
-#     assert getattr(grp2Pkg2, attr) == 'grp2_pkg2_%s'%attr
-#   for attr in ['buildOnly', 'disablePatch']:
-#     assert getattr(grp2Pkg2, attr) is False
+from pytest import mark
+parametrize = mark.parametrize
+
+testDir = os.path.join(os.path.dirname(__file__), 'testFiles')
+
 
 def test_get_all_packages():
   """ Check that we get all the packages in the correct order
       and with correct inheritance
   """
+  json_test_file = os.path.join(os.path.dirname(__file__), 'testFiles/config_test.json')
+  cfg = Conf.load(json_test_file)
   allPackages = cfg['allPackagesConfig']
+
+  # Most paths should be relative now !
 
   assert len(allPackages) == 4
 
   pkg1 = allPackages[0]
   assert pkg1['name'] == 'grp1_pkg1_name'
-  assert pkg1['mockRoot'] == 'grp1_pkg1_mockRoot'
+
+  assert pkg1['mockRoot'] == os.path.join(testDir, 'grp1_pkg1_mockRoot')
 
   pkg2 = allPackages[1]
   assert pkg2['name'] == 'grp1_pkg2_name'
-  assert pkg2['mockRoot'] == 'grp1_mockRoot'
+  assert pkg2['mockRoot'] == os.path.join(testDir, 'grp1_mockRoot')
 
   pkg3 = allPackages[2]
   assert pkg3['name'] == 'grp2_pkg1_name'
-  assert pkg3['mockRoot'] == 'grp2_pkg1_mockRoot'
+  assert pkg3['mockRoot'] == os.path.join(testDir, 'grp2_pkg1_mockRoot')
 
   pkg4 = allPackages[3]
   assert pkg4['name'] == 'grp2_pkg2_name'
-  assert pkg4['mockRoot'] == 'mockRoot'
+  assert pkg4['mockRoot'] == os.path.join(testDir, 'mockRoot')
+
+
+def test_resolve_mockConfig():
+  """ mockConfig should resolved to an absolute path, except if it is a standard config"""
+
+  json_test_file = os.path.join(os.path.dirname(__file__), 'testFiles/config_test.json')
+  cfg = Conf.load(json_test_file)
+  allPackages = cfg['allPackagesConfig']
+
+  # If the mockConfig is a '.cfg' path, it should be resolved to an absolute path
+  pkg1 = allPackages[0]
+  assert pkg1['mockConfig'] == os.path.join(testDir, 'grp1_pkg1_mockConfig.cfg')
+
+  # If not, it should stay as it is
+  pkg2 = allPackages[2]
+  assert pkg2['mockConfig'] == 'grp2_pkg1_mockConfig'
+
+
+pipRequirementsTests = [
+    # URL case
+    (os.path.join(
+        testDir,
+        'pip_req_url.json'),
+        "https://aURL.com/requirements.txt"),
+    # path case
+    (os.path.join(
+        testDir,
+        'pip_req_file.json'),
+     os.path.abspath(os.path.join(
+         testDir,
+         "../requirements.txt")))]
+
+
+@parametrize("cfgFile,pipReqExpected", pipRequirementsTests)
+def test_resolve_requirement(cfgFile, pipReqExpected):
+  """pipRequirement can be a url or a path
+     If we have an URL, it should stay as is
+     If it is a path, we want it to be resolved to absolute path
+  """
+
+  cfg = Conf.load(cfgFile)
+  requirementURL = cfg['pipRequirements']
+  assert requirementURL == pipReqExpected


### PR DESCRIPTION
Copy the requirements.txt from DIRAC, and put it in this repo. it will be slimmed down later
Also allows to have it as a file or a url in the configuration

@fstagni can you review please ?
Also, I just realized that all the unit tests of DIRAC:
* either have to use this requirements.txt
* or we have to keep it duplicated and synced
* keep it so relaxed that we do not need to care about sync, except when adding a package

BEGINRELEASENOTES

NEW: requirements.txt copied from DIRAC
NEW: scripts to fix the package versions in the pip requirement file
CHANGE: allow to have pipRequirements a URL or a file
CHANGE: split the doc


ENDRELEASENOTES