### PR TITLE
Add tests for SLC6, CC7, fedora and ubuntu

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,9 +4,10 @@ variables:
 
 stages:
     - compile
+    - test
     - deploy
 
-SLC6:
+compile:
   stage: compile
   retry: 2
   tags:
@@ -22,16 +23,54 @@ SLC6:
     - pip install git+https://github.com/DIRACGrid/DIRACOS.git
     - sed -i -e 's/-j4/-j16/g' mockConfigs/mock-build-diracos.cfg
     - dos-build-all-rpms config/diracos.json
+    - dos-fix-pip-versions config/diracos.json
+    - mkdir -p public/${CI_COMMIT_REF_NAME}
+    - cp /var/lib/mock/epel-6-x86_64-install/root/tmp/fixed_requirements.txt public/${CI_COMMIT_REF_NAME}/.
     - dos-build-python-modules config/diracos.json
     - dos-bundle config/diracos.json
-    - mkdir -p public/${CI_COMMIT_REF_NAME}
     - cp /var/lib/mock/epel-6-x86_64-install/root/tmp/diracos-${CI_COMMIT_REF_NAME}.tar.gz public/${CI_COMMIT_REF_NAME}/diracos-${CI_COMMIT_REF_NAME}.tar.gz
     - cd public/${CI_COMMIT_REF_NAME}
     - md5sum diracos-${CI_COMMIT_REF_NAME}.tar.gz | awk {'print $1'} > diracos-${CI_COMMIT_REF_NAME}.md5
   artifacts:
     paths:
       - public
-    expire_in: 1 hour
+    expire_in: 1 week
+
+
+# Run tests
+
+.run_test:
+  stage: test
+  tags:
+    - docker
+  script:
+    - tar xf public/${CI_COMMIT_REF_NAME}/diracos-${CI_COMMIT_REF_NAME}.tar.gz -C /tmp
+    - export DIRACOS=/tmp/diracos
+    - source $DIRACOS/diracosrc
+    - pytest tests/integration/test_import.py
+  dependencies:
+    - compile
+
+SLC6:
+  extends: .run_test
+  image: cern/slc6-base
+  before_script:
+    - yum install tar -y
+
+CC7:
+  extends: .run_test
+  image: cern/cc7-base
+
+fedora-latest:
+  extends: .run_test
+  image: fedora:latest
+  allow_failure: true
+
+ubuntu-latest:
+  extends: .run_test
+  image: ubuntu:latest
+  allow_failure: true
+
 
 # Deploy to EOS folder
 deployment:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DIRACOS
 
-[![pipeline status](https://gitlab.cern.ch/CLICdp/iLCDirac/DIRACOS/badges/master/pipeline.svg)](https://gitlab.cern.ch/CLICdp/iLCDirac/DIRACOS/commits/master)
+[![pipeline status](https://gitlab.cern.ch/CLICdp/iLCDirac/DIRACOS/badges/master/pipeline.svg)](https://gitlab.cern.ch/CLICdp/iLCDirac/DIRACOS/pipelines)
 
 DIRACOS aims at bringing in one archive all the dependencies needed by DIRAC.
 

--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ do grep '^#' $doc | while read title;
 done
 
 ```
+
+## Disclaimer
+DIRACOS is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. We are aiming at supporting SLC6 and CC7, whilst we test also on other platforms we do not provide support for those.

--- a/docs/70_release.md
+++ b/docs/70_release.md
@@ -68,6 +68,8 @@ This script requires the same setup as a build of DIRACOS. Thus, you can already
 
 You can then get the output file (`/var/lib/mock/epel-6-x86_64-install/root/tmp/fixed_requirements.txt`) and put it in replacement of the existing `requirements.txt`, after inspecting it.
 
+NOTE:  You have to execute `dos-fix-pip-versions` after you executed  `dos-build-all-rpms` and you need to copy `fixed_requirements.txt` out of  `/var/lib/mock/epel-6-x86_64-install/root/tmp/` before proceeding with the execution of any other command as it might delete `fixed_requirements.txt`.
+
 Once you are satisfied, you can update the version in the json file, commit, tag and push the branch
 
 ```


### PR DESCRIPTION
BEGINRELEASENOTES
NEW: add tests of DIRACOS on CC7, SLC6, ubuntu, fedora
ENDRELEASENOTES
needs #45 