### PR TITLE
FIX: fix fedora's tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -124,8 +124,9 @@ fedora-latest:
   extends: .run_test
   image: fedora:latest
   allow_failure: true
-  variables:
-    LD_PRELOAD: "/lib64/libselinux.so.1"
+  before_script:
+    # Needed for ARC
+    - yum install -y libnsl
 
 ubuntu-latest:
   extends: .run_test

--- a/docs/0_concepts.md
+++ b/docs/0_concepts.md
@@ -38,4 +38,4 @@ Only SLC6 and CC7 are supported. We have automated tests for the LTS Ubuntu and 
 
 ### Trick
 
-On the latest Fedora, we noticed that adding a `LD_PRELOAD` fixes the tests, but again, use at your own risk, and do not ask for support
+If the tests are green, you can check gitlab-ci.yml to see what are the hooks we use to make the tests work on Fedora and Ubuntu. But again, use at your own risk, and do not ask for support.


### PR DESCRIPTION
BEGINRELEASENOTES
FIX: fix fedora's tests for F29

ENDRELEASENOTES
