### PR TITLE
Fix DIRACOS inference

### DIFF
--- a/diracos/bundlelib.py
+++ b/diracos/bundlelib.py
@@ -172,7 +172,7 @@ grep -rIl '#!/usr/bin/python' /tmp/diracos | xargs sed -i 's:#!/usr/bin/python:#
 echo "Generating diracosrc $DIRACOSRC"
 
 # If DIRACOS is not defined, we define it as the current location
-echo -e "if [ -z \$DIRACOS ];\nthen\n\tDIRACOS=\$(dirname \"\$(readlink -f \"\$0\")\");\n\texport DIRACOS;\nfi\n" > $DIRACOSRC
+echo -e "if [ -z \$DIRACOS ];\\nthen\\n\\tDIRACOS=\$(dirname \$(readlink -f "\$0"));\\n\\texport DIRACOS;\\nfi\\n" > $DIRACOSRC
 
 
 DIRACOS_LD_LIBRARY_PATH=$(find -L $DIRACOS -name '*.so' -printf "%%h\n" | sort -u | sed -E "s|^$DIRACOS|\$DIRACOS|g" | sort -u | paste -sd ':')


### PR DESCRIPTION
That should fix it... I should write unit tests for all that, but not trivial..
BEGINRELEASENOTES
FIX: DIRACOS inference was buggy
ENDRELEASENOTES
The change is from 
```sh
if [ -z $DIRACOS ];
then
	DIRACOS=$(dirname $(readlink -f $0));
	export DIRACOS;
fi
```
to
```sh
if [ -z $DIRACOS ];
then
	DIRACOS=$(dirname "$(readlink -f "$0")");
	export DIRACOS;
fi
```