### PR TITLE
DIRACOS tools to 1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,9 @@ Session.vim
 .idea/
 DIRAC.iml
 
+#vsvode
+.vscode
+
 # MaxOSX files
 .DS_Store
 

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -1,5 +1,4 @@
 # From repo
-git+https://:@gitlab.cern.ch:8443/fts/fts-rest.git#egg=fts3
 git+https://github.com/DIRACGrid/pyGSI.git#egg=GSI
 
 # From pypi
@@ -8,6 +7,7 @@ certifi
 CMRESHandler>=1.0.0b4
 codecov
 elasticsearch-dsl>=2.0.0
+fts3-rest
 funcsigs
 futures
 GitPython>=2.1.0

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -6,6 +6,7 @@ git+https://github.com/DIRACGrid/pyGSI.git#egg=GSI
 autopep8==1.3.3
 certifi
 CMRESHandler>=1.0.0b4
+codecov
 elasticsearch-dsl>=2.0.0
 funcsigs
 futures
@@ -25,7 +26,6 @@ pylint>=1.6.5
 pyparsing>=2.0.6
 pytest>=2.8.5
 pytest-cov>=2.2.0
-python-coveralls
 pytz>=2015.7
 readline>=6.2.4
 requests>=2.9.1

--- a/diracos/__init__.py
+++ b/diracos/__init__.py
@@ -1,0 +1,19 @@
+from os import path
+
+# Location of the script templates
+SCRIPT_TPL_PATH = path.join(path.dirname(path.realpath(__file__)), 'scriptTemplates')
+
+# The script template to build the python module
+BUILD_PYTHON_MODULE_SH_TPL_PATH = path.join(SCRIPT_TPL_PATH, 'build_python_module_tpl.sh')
+
+# Tpl to freeze the versions of the pip modules we will use
+FIX_PIP_REQUIREMENTS_VERSIONS_SH_TPL_PATH = path.join(SCRIPT_TPL_PATH, 'fix_pip_requirements_versions_tpl.sh')
+
+# Tpl script to make a bundle of everything
+BUNDLE_DIRACOS_SCRIPT_SH_TPL_PATH = path.join(SCRIPT_TPL_PATH, 'bundle_diracos_script_tpl.sh')
+
+# Tpl script of diracosrc
+DIRACOSRC_TPL_PATH = path.join(SCRIPT_TPL_PATH, 'diracosrc_tpl.sh')
+
+# The python bundling script that we have to put in the mock environment
+PYTHON_BUNDLE_LIB_PATH = path.join(path.dirname(path.realpath(__file__)), 'bundlelib.py')

--- a/diracos/bundlelib.py
+++ b/diracos/bundlelib.py
@@ -135,135 +135,6 @@ def _resolveAllPackageDependencyURLs(requiredPkg=None, ignoredPackages=None):
   return _getPackagesURLs(pkgs)
 
 
-BUNDLE_DIRACOS_SCRIPT_TPL = """#!/bin/bash
-
-
-# The list of PKGs we want to distribute.
-# If not given as parameter, all the rpms in the x86_64 and noarch subfolder
-# of the building repository will be used.
-DIRACOS_VERSION=%(diracOsVersion)s
-PKG_URLS="%(requiredPackages)s"
-REMOVED_FOLDERS="%(removedFolders)s"
-
-# Location where the bundle takes place
-DIRACOS=/tmp/diracos
-DIRACOSRC=$DIRACOS/diracosrc
-DIRACOS_VERSION_FILE=$DIRACOS/versions.txt
-
-
-echo "Extracting rpms $PKG_URLS"
-
-mkdir $DIRACOS
-cd $DIRACOS
-for i in $PKG_URLS; do curl -L $i | rpm2cpio | cpio -dvim; done
-
-echo "Copying python modules"
-cp -r /tmp/pipDirac/lib/* $DIRACOS/usr/lib64/
-cp -r /tmp/pipDirac/bin/ $DIRACOS/usr/
-
-echo "Deleting empty directories"
-find $DIRACOS -type d -empty -delete
-
-# Fix the shebang for python
-echo "Fixing the shebang"
-grep -rIl '#!/usr/bin/python' /tmp/diracos | xargs sed -i 's:#!/usr/bin/python:#!/usr/bin/env python:g'
-
-# Generating the diracosrc
-echo "Generating diracosrc $DIRACOSRC"
-
-# If DIRACOS is not defined, we define it as the current location
-echo -e "if [ -z \$DIRACOS ];\\nthen\\n\\tDIRACOS=\$(dirname \$(readlink -f "\$BASH_SOURCE"));\\n\\texport DIRACOS;\\nfi\\n" > $DIRACOSRC
-
-
-DIRACOS_LD_LIBRARY_PATH=$(find -L $DIRACOS -name '*.so' -printf "%%h\n" | sort -u | sed -E "s|^$DIRACOS|\$DIRACOS|g" | sort -u | paste -sd ':')
-echo "LD_LIBRARY_PATH=$DIRACOS_LD_LIBRARY_PATH:\$LD_LIBRARY_PATH" >> $DIRACOSRC
-echo "export LD_LIBRARY_PATH" >> $DIRACOSRC
-
-echo "PATH=\$DIRACOS/bin:\$DIRACOS/usr/bin:\$DIRACOS/sbin:\$DIRACOS/usr/sbin:\$PATH" >> $DIRACOSRC
-echo "export PATH" >> $DIRACOSRC
-
-echo '# Silence the python warnings' >> $DIRACOSRC
-echo 'export PYTHONWARNINGS="ignore"' >> $DIRACOSRC
-
-# add the list of rpms and python packages for info
-echo "Adding the version list $DIRACOS_VERSION_FILE"
-
-
-echo -e "DIRACOS $DIRACOS_VERSION $(date -u)\n\n" > $DIRACOS_VERSION_FILE
-echo -e "===== RPM packages ====\n\n" >> $DIRACOS_VERSION_FILE
-cat /tmp/rpms.txt | sort >> $DIRACOS_VERSION_FILE
-echo -e "\n\n===== Python packages ====\n\n" >> $DIRACOS_VERSION_FILE
-cat /tmp/requirements.txt | sort >> $DIRACOS_VERSION_FILE
-
-# Doing some cleanup
-echo "Removing useless folders"
-for fold in $REMOVED_FOLDERS;
-do
-  echo "Removing $DIRACOS/$fold"
-  rm -rf $DIRACOS/$fold;
-done
-
-# Remove pyo and pyc
-find $DIRACOS -name '*.py[oc]' -exec rm {} \;
-
-###############################################
-# Here we just go through the symlinks, list
-# the broken ones. We will compare them
-# to a list of known broken links a posteriori
-# The synlinks that points outside of diracos are
-# replaced with a copy of the file
-echo "Finding all the broken symlinks"
-
-# Find all the symlinks
-brokenLinks=$(
-for i in $(find $DIRACOS -type l);
-do
-  # Find the target of the symlink
-  fp=$(readlink $i);
-
-  # If the target is an absolute path, but not in DIRACOS
-  if [ $(echo $fp | sed "s|^$DIRACOS|./|g" | grep -cE '^/') -ne 0 ];
-  then
-    # If the target file does not exist, print a warning
-    if [ ! -f $fp ];
-    then
-      # We display the link, but replace the actual DIRACOS path with just 'DIRACOS'
-      echo -n "$i\\n" | sed "s|^$DIRACOS|DIRACOS|g";
-      # And we remove it
-      rm $i;
-    else
-      # copy the original file
-      cp --remove-destination $fp $i;
-    fi;
-  fi;
-done)
-
-echo "Found broken symlinks, put them in $DIRACOS/brokenLinks.txt"
-
-# The file MUST be sorted for comparison, and we remove the empty lines
-echo -e $brokenLinks | sort | sed '/^$/d' > $DIRACOS/brokenLinks.txt
-
-###############################
-
-cd /tmp
-# The hard-dereference options allow to replace a hard link with a copy of the file.
-# A link pointing to nowhere would just be removed.
-# We do not use the dereference option (for symlinks) because there are just too many
-tar --hard-dereference -cvzf diracos-$DIRACOS_VERSION.tar.gz diracos
-
-tarRc=$?
-# tar will probably return 1 because of --dereference and --hard-dereference (man tar is your friend)
-# So I consider the tar a success if the returned code is 0 or 1
-if [ $tarRc -eq 0 ] || [ $tarRc -eq 1 ];
-then
-  exit 0;
-fi;
-exit $tarRc
-
-
-"""
-
-
 def _doBundleDIRACOS(diracOsVersion, requiredPkg=None, repository=None, ignoredPackages=None, removedFolders=None):
   """
       Create the final diracos tarball.
@@ -308,10 +179,20 @@ def _doBundleDIRACOS(diracOsVersion, requiredPkg=None, repository=None, ignoredP
   if not removedFolders:
     removedFolders = ['aStupidRandomNameToAvoidDeletingSomethingUseful']
 
+  # At this point in time, we are in the mock environment. So the template shell script
+  # will not be anymore where BUNDLE_DIRACOS_SCRIPT_SH_TPL_PATH points,
+  # but in /tmp/, because that's where diracoslib.py put it before
+  # Also, we have no access to the BUNDLE_DIRACOS_SCRIPT_SH_TPL_PATH variable anymore anyway
+
+  bundleTpmPath = '/tmp/bundle_diracos_script_tpl.sh'
+
+  with open(bundleTpmPath, 'r') as tplFile:
+    bundle_diracos_script_tpl = ''.join(tplFile.readlines())
+
   shellBundleScript = '/tmp/bundleDiracOS.sh'
   with open(shellBundleScript, 'w') as sbs:
     sbs.write(
-        BUNDLE_DIRACOS_SCRIPT_TPL % {
+        bundle_diracos_script_tpl % {
             'diracOsVersion': diracOsVersion,
             'requiredPackages': ' '.join(urlList),
             'removedFolders': ' '.join(removedFolders)})

--- a/diracos/scriptTemplates/build_python_module_tpl.sh
+++ b/diracos/scriptTemplates/build_python_module_tpl.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This script is normally called automatically with the arguments taken from the json configuration file
+
+PIP_BUILD_DEPENDENCIES="%(pipBuildDependencies)s"
+PIP_DIRAC=/tmp/pipDirac
+
+echo "Installing pip"
+cd /tmp
+curl -O -L https://bootstrap.pypa.io/get-pip.py
+python get-pip.py
+
+echo "Preparing to build pythong packages"
+
+echo "Pip build dependencies $PIP_BUILD_DEPENDENCIES"
+
+echo "Installing dependency"
+yum install $PIP_BUILD_DEPENDENCIES
+
+yum install python2-virtualenv
+
+# We use the --always-copy option in order not to have symlinks to the system.
+# However, we cannot just do virtualenv --always-copy /tmp/pipDirac
+# See: https://github.com/pypa/virtualenv/issues/565#issuecomment-305002914
+
+mkdir $PIP_DIRAC
+cd $PIP_DIRAC
+virtualenv .
+cd /tmp/
+
+source $PIP_DIRAC/bin/activate
+pip install -r /tmp/requirements.txt
+virtualenv --relocatable $PIP_DIRAC
+
+# Dump the full list of python packages
+pip freeze 2>/dev/null 1> /tmp/pythonPackages.txt

--- a/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
+++ b/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+
+# The list of PKGs we want to distribute.
+# If not given as parameter, all the rpms in the x86_64 and noarch subfolder
+# of the building repository will be used.
+DIRACOS_VERSION=%(diracOsVersion)s
+PKG_URLS="%(requiredPackages)s"
+REMOVED_FOLDERS="%(removedFolders)s"
+
+# Location where the bundle takes place
+DIRACOS=/tmp/diracos
+DIRACOSRC=$DIRACOS/diracosrc
+DIRACOS_VERSION_FILE=$DIRACOS/versions.txt
+
+
+echo "Extracting rpms $PKG_URLS"
+
+mkdir $DIRACOS
+cd $DIRACOS
+for i in $PKG_URLS; do curl -L $i | rpm2cpio | cpio -dvim; done
+
+echo "Copying python modules"
+cp -r /tmp/pipDirac/lib/* $DIRACOS/usr/lib64/
+cp -r /tmp/pipDirac/bin/ $DIRACOS/usr/
+
+echo "Deleting empty directories"
+find $DIRACOS -type d -empty -delete
+
+# Fix the shebang for python
+echo "Fixing the shebang"
+grep -rIl '#!/usr/bin/python' /tmp/diracos | xargs sed -i 's:#!/usr/bin/python:#!/usr/bin/env python:g'
+
+# Generating the diracosrc
+echo "Generating diracosrc $DIRACOSRC"
+
+# Find all the libraries in the diracos folder in order to build the LD_LIBRARY_PATH
+# We also replace the localy resolved DIRACOS path with the variable '$DIRACOS' such
+# that it is resolved at source time
+DIRACOS_LD_LIBRARY_PATH=$(find -L $DIRACOS -name '*.so' -printf "%%h\n" | sort -u | sed -E "s|^$DIRACOS|\$DIRACOS|g" | sort -u | paste -sd ':')
+
+# Replace the DIRACOS_LD_LIBRARY_PATH text in the diracosrc template with the libraries just found
+# reminder: the /tmp/diracosrc_tpl.sh file was put there in the bundling bootstrap of diracoslib
+sed "s|DIRACOS_LD_LIBRARY_PATH|$DIRACOS_LD_LIBRARY_PATH|g" /tmp/diracosrc_tpl.sh > $DIRACOSRC
+
+# add the list of rpms and python packages for info
+echo "Adding the version list $DIRACOS_VERSION_FILE"
+
+
+echo -e "DIRACOS $DIRACOS_VERSION $(date -u)\n\n" > $DIRACOS_VERSION_FILE
+echo -e "===== RPM packages ====\n\n" >> $DIRACOS_VERSION_FILE
+cat /tmp/rpms.txt | sort >> $DIRACOS_VERSION_FILE
+
+echo -e "\n\n===== Python packages ====\n\n" >> $DIRACOS_VERSION_FILE
+# reminder: this file was generated when building the python modules
+cat /tmp/pythonPackages.txt | sort >> $DIRACOS_VERSION_FILE
+
+# Doing some cleanup
+echo "Removing useless folders"
+for fold in $REMOVED_FOLDERS;
+do
+  echo "Removing $DIRACOS/$fold"
+  rm -rf $DIRACOS/$fold;
+done
+
+# Remove pyo and pyc
+find $DIRACOS -name '*.py[oc]' -exec rm {} \;
+
+###############################################
+# Here we just go through the symlinks, list
+# the broken ones. We will compare them
+# to a list of known broken links a posteriori
+# The synlinks that points outside of diracos are
+# replaced with a copy of the file
+echo "Finding all the broken symlinks"
+
+# Find all the symlinks
+brokenLinks=$(
+for i in $(find $DIRACOS -type l);
+do
+  # Find the target of the symlink
+  fp=$(readlink $i);
+
+  # If the target is an absolute path, but not in DIRACOS
+  if [ $(echo $fp | sed "s|^$DIRACOS|./|g" | grep -cE '^/') -ne 0 ];
+  then
+    # If the target file does not exist, print a warning
+    if [ ! -f $fp ];
+    then
+      # We display the link, but replace the actual DIRACOS path with just 'DIRACOS'
+      echo -n "$i\n" | sed "s|^$DIRACOS|DIRACOS|g";
+      # And we remove it
+      rm $i;
+    else
+      # copy the original file
+      cp --remove-destination $fp $i;
+    fi;
+  fi;
+done)
+
+echo "Found broken symlinks, put them in $DIRACOS/brokenLinks.txt"
+
+# The file MUST be sorted for comparison, and we remove the empty lines
+echo -e $brokenLinks | sort | sed '/^$/d' > $DIRACOS/brokenLinks.txt
+
+###############################
+
+cd /tmp
+# The hard-dereference options allow to replace a hard link with a copy of the file.
+# A link pointing to nowhere would just be removed.
+# We do not use the dereference option (for symlinks) because there are just too many
+tar --hard-dereference -cvzf diracos-$DIRACOS_VERSION.tar.gz diracos
+
+tarRc=$?
+# tar will probably return 1 because of --dereference and --hard-dereference (man tar is your friend)
+# So I consider the tar a success if the returned code is 0 or 1
+if [ $tarRc -eq 0 ] || [ $tarRc -eq 1 ];
+then
+  exit 0;
+fi;
+exit $tarRc

--- a/diracos/scriptTemplates/diracosrc_tpl.sh
+++ b/diracos/scriptTemplates/diracosrc_tpl.sh
@@ -1,0 +1,22 @@
+# This file is generated at bundle time
+
+# If DIRACOS is not defined, define it as the directory
+# in which the current script is stored
+
+if [ -z $DIRACOS ];
+then
+  DIRACOS=$(dirname $(readlink -f "$BASH_SOURCE"));
+  export DIRACOS;
+fi
+
+
+# Define the LD_LIBRARY_PATH
+LD_LIBRARY_PATH=DIRACOS_LD_LIBRARY_PATH:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH
+
+# Define the path
+PATH=$DIRACOS/bin:$DIRACOS/usr/bin:$DIRACOS/sbin:$DIRACOS/usr/sbin:$PATH
+export PATH
+
+# Silence the python warnings
+export PYTHONWARNINGS="ignore"

--- a/diracos/scriptTemplates/fix_pip_requirements_versions_tpl.sh
+++ b/diracos/scriptTemplates/fix_pip_requirements_versions_tpl.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# This script is normally called automatically with the arguments taken from the json configuration file
+
+
+# This is the file containing the loose requirements
+# It was copied there by fixPipRequirementsVersions
+PIP_REQUIREMENTS_LOOSE=/tmp/loose_requirements.txt
+
+# This is the output files containing strict versions
+PIP_REQUIREMENTS_FIXED=/tmp/fixed_requirements.txt
+
+
+# the list of dependencies of to build the package
+# and also fetch their dependency by pip-compile
+PIP_BUILD_DEPENDENCIES="%(pipBuildDependencies)s"
+
+
+
+echo "Installing pip"
+cd /tmp
+curl -O -L https://bootstrap.pypa.io/get-pip.py
+python get-pip.py
+
+echo "Installing pip-tools"
+pip install pip-tools
+
+
+# We need to install the dependencies such that pip-compile
+# can work
+echo "Pip build dependencies $PIP_BUILD_DEPENDENCIES"
+
+echo "Installing dependency"
+yum install -y $PIP_BUILD_DEPENDENCIES
+
+
+echo "Fixing the version"
+
+
+# First, get all the python packages which are not taken from git
+
+grep -v 'git+' $PIP_REQUIREMENTS_LOOSE > $PIP_REQUIREMENTS_FIXED
+
+# If there are packages from git, we can't compile them, so print a warning
+
+gitPackages=$(grep 'git+https' $PIP_REQUIREMENTS_LOOSE)
+# gitpackageFound is 0 if packages were found
+gitPackagesRc=$?
+
+if [ $gitPackagesRc -eq 0 ];
+then
+  echo "WARNING: cannot compile following packages"
+  for pkg in $gitPackages;
+  do
+    echo $pkg;
+  done;
+fi
+
+
+# Now, compile all the non packages
+# The change is done in place
+pip-compile -v $PIP_REQUIREMENTS_FIXED
+compileRc=$?
+
+if [ $compileRc -ne 0 ];
+then
+  echo "ERROR fixing version, exiting";
+  exit 1;
+fi
+
+# add back the git packages
+
+grep 'git+https' $PIP_REQUIREMENTS_LOOSE >> $PIP_REQUIREMENTS_FIXED
+
+
+# # First, copy the git requirements to the target file
+# grep 'git+' PIP_REQUIREMENTS_LOOSE > fixed_requirements.txt
+
+# # Add the strict versions
+# grep '==' PIP_REQUIREMENTS_LOOSE >> fixed_requirements.txt
+
+# # Transform the '<=' requirements into '=='
+# grep '<=' loose_requirements.txt | sed 's/<=/==/g' >> fixed_requirements.txt
+
+# # For all the '>=', check the latest versions known to pip, and use that one
+# for pkg in $(grep '>=' loose_requirements.txt | awk -F '[>=]' {'print $1'});
+# do
+#   # When asking pip to install version 0.0.0, it will fail and list you which available versions there are
+#   latest=$(pip install $pkg==0.0.0 2>&1 | grep 'from versions' | awk -F '[,:]' {'print $NF'} | sed -e 's/)//g' -e 's/ //g');
+#   echo "$pkg==$latest";
+# done >> fixed_requirements.txt
+
+
+# # For all the non specified version, check the latest versions known to pip, and use that one
+# for pkg in $(grep -vE '(=|#|git)' loose_requirements.txt |  awk  {'print $1'});
+# do
+#   # When asking pip to install version 0.0.0, it will fail and list you which available versions there are
+#   latest=$(pip install $pkg==0.0.0 2>&1 | grep 'from versions' | awk -F '[,:]' {'print $NF'} | sed -e 's/)//g' -e 's/ //g');
+#   echo "$pkg==$latest";
+# done >> fixed_requirements.txt

--- a/scripts/fixPipRequirementsVersions.py
+++ b/scripts/fixPipRequirementsVersions.py
@@ -11,15 +11,16 @@ def main():
   jsonConf = sys.argv[1]
 
   cfg = Conf.load(jsonConf)
-  #pprint.pprint(allPackages)
 
   mockInstallConfig = cfg['mockInstallConfig']
   mockInstallRoot = cfg['mockInstallRoot']
-  pipRequirements=  cfg['pipRequirements']
+  pipRequirements = cfg['pipRequirements']
+  pipBuildDependencies = cfg['pipBuildDependencies']
 
+  fixedVersionFile = diracoslib.fixPipRequirementsVersions(
+      mockInstallConfig, mockInstallRoot, pipRequirements, pipBuildDependencies)
+  print "Fixed version file in %s" % fixedVersionFile
 
-  fixedVersionFile = diracoslib.fixPipRequirementsVersions(mockInstallConfig, mockInstallRoot, pipRequirements)
-  print "Fixed version file in %s"%fixedVersionFile
 
 if __name__ == '__main__':
   main()

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ base_dir = os.path.dirname(__file__)
 setup(
     name='diracos',
     description='Tools to build DIRACOS',
-    version="0.0.1",
+    version="1.0.0",
     author='Christophe Haen',
     author_email='christophe.haen@cern.ch',
     url='https://github.com/DIRACGrid/DIRACOS',
@@ -23,5 +23,6 @@ setup(
                             'dos-fix-pip-versions=scripts.fixPipRequirementsVersions:main'
                              ],
     },
-    packages=find_packages()
+    packages=find_packages(),
+    package_data = {'diracos': ['scriptTemplates/*']},
 )


### PR DESCRIPTION
The biggest change here is that the shell scripts are put in separate files. It's more readable

BEGINRELEASENOTES
CHANGE: take fts3-rest from pipy instead of github. Replace coverall with codecov.
CHANGE: reorganizing the diracos tools for better readability of the scripts
CHANGE: use pip-tools to compile the python package versions, and use pip freeze for listing all the packages shipped 
ENDRELEASENOTES
