### PR TITLE
Exit on error and M2Crypto

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -13,6 +13,7 @@ futures
 GitPython>=2.1.0
 matplotlib>=2.1.0
 mock>=1.0.1
+M2Crypto==0.32.0
 MySQL-python>=1.2.5
 jinja2
 ipython==5.3.0

--- a/diracos/scriptTemplates/build_python_module_tpl.sh
+++ b/diracos/scriptTemplates/build_python_module_tpl.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This script is normally called automatically with the arguments taken from the json configuration file
 
+# Exit directly in case of errors
+set -e
+
 PIP_BUILD_DEPENDENCIES="%(pipBuildDependencies)s"
 PIP_DIRAC=/tmp/pipDirac
 

--- a/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
+++ b/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Exit directly in case of errors
+set -e
 
 # The list of PKGs we want to distribute.
 # If not given as parameter, all the rpms in the x86_64 and noarch subfolder

--- a/diracos/scriptTemplates/fix_pip_requirements_versions_tpl.sh
+++ b/diracos/scriptTemplates/fix_pip_requirements_versions_tpl.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This script is normally called automatically with the arguments taken from the json configuration file
 
+# Exit directly in case of errors
+set -e
 
 # This is the file containing the loose requirements
 # It was copied there by fixPipRequirementsVersions

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -64,6 +64,7 @@ moduleNames = [
     'itertools',
     'json',
     'logging',
+    'M2Crypto',
     'math',
     'matplotlib',
     'mock',


### PR DESCRIPTION
BEGINRELEASENOTES
NEW: Explicitly require M2Crypto 0.32.0
FIX: bash scripts exit on errors
ENDRELEASENOTES
