### PR TITLE
DIRACOS: use rsync to copy python modules

### DIFF
--- a/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
+++ b/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
@@ -22,8 +22,12 @@ mkdir $DIRACOS
 cd $DIRACOS
 for i in $PKG_URLS; do curl -L $i | rpm2cpio | cpio -dvim; done
 
+# We need to copy the python modules using rsync
+# because some directory are overwriten by files
+yum install -y rsync
+
 echo "Copying python modules"
-cp -r /tmp/pipDirac/lib/* $DIRACOS/usr/lib64/
+rsync -zvr /tmp/pipDirac/lib/ $DIRACOS/usr/lib64/
 cp -r /tmp/pipDirac/bin/ $DIRACOS/usr/
 
 echo "Deleting empty directories"


### PR DESCRIPTION
Fixes the error `cp: cannot overwrite directory `/tmp/diracos/usr/lib64/python2.7/config' with non-directory`

Seems to work: https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/pipelines/838706


BEGINRELEASENOTES

FIX: use rsync to copy python modules in diracos

ENDRELEASENOTES
