### PR TITLE
Bump versions of Davix, gfal2, gfal2-python

### DIFF
--- a/config/diracos.json
+++ b/config/diracos.json
@@ -457,7 +457,7 @@
             "name": "davix",
             "packages": [
                {
-                  "src": "https://diracos.web.cern.ch/diracos/SRPM/davix-0.6.6-r1705170955.src.rpm",
+                  "src": "https://diracos.web.cern.ch/diracos/SRPM/davix-0.7.2-2.el6.src.rpm",
                   "name": "davix"
                }
             ]

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -520,9 +520,7 @@
                   "buildOnly": true
                },
                {
-                  "comment": "Carreful, testing package",
-                  "src": "https://diracos.web.cern.ch/diracos/SRPM/gfal2-2.15.4-1.el6.src.rpm",
-                  "src_old": "http://dmc-repo.web.cern.ch/dmc-repo/testing/el6/x86_64/gfal2-2.15.2-r1803011640.el6.src.rpm",
+                  "src": "https://diracos.web.cern.ch/diracos/SRPM/gfal2-2.16.1-1.el6.src.rpm",
                   "excludePatterns": [
                      ".*-doc-.*",
                      ".*-debuginfo-.*",

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -529,7 +529,7 @@
                   "name": "gfal2"
                },
                {
-                  "src": "https://diracos.web.cern.ch/diracos/SRPM/gfal2-python-1.9.3-1.el6.src.rpm",
+                  "src": "https://diracos.web.cern.ch/diracos/SRPM/gfal2-python-1.9.5-1.el6.src.rpm",
                   "name": "gfal2-python"
                },
                {

--- a/patches/davix.patch
+++ b/patches/davix.patch
@@ -1,28 +1,36 @@
-diff -u -r davix-orig/davix.spec davix-patched/davix.spec
---- davix-orig/davix.spec	2017-05-17 09:55:19.000000000 +0200
-+++ davix-patched/davix.spec	2018-03-27 15:34:37.202090474 +0200
-@@ -25,11 +25,6 @@
+diff -u -r original/davix.spec modified/davix.spec
+--- original/davix.spec 2019-03-20 11:54:36.000000000 +0100
++++ modified/davix.spec 2019-05-08 17:37:46.416589447 +0200
+@@ -25,10 +25,6 @@
  # davix-copy dependencies
  BuildRequires:                  gsoap-devel
-
+ BuildRequires:                  libuuid-devel
 -# unit tests and abi check
 -%if %{?fedora}%{!?fedora:0} >= 10 || %{?rhel}%{!?rhel:0} >= 6
 -BuildRequires:                  abi-compliance-checker
 -%endif
--BuildRequires:                  gtest-devel
 
  Requires:                       %{name}-libs%{?_isa} = %{version}-%{release}
-
-@@ -97,12 +92,6 @@
+ Requires:                       libuuid
+@@ -86,18 +82,15 @@
  make %{?_smp_mflags}
  make doc
 
 -%check
 -%if %{?fedora}%{!?fedora:0} >= 10 || %{?rhel}%{!?rhel:0} >= 6
--make abi-check
+-#make abi-check
 -%endif
 -ctest -V -T Test
--
+
 
  %install
  rm -rf %{buildroot}
+ make DESTDIR=%{buildroot} install
+
+-%ldconfig_scriptlets libs
++%post libs -p /sbin/ldconfig
++
++%postun libs -p /sbin/ldconfig
+
+ %files
+ %{_bindir}/*


### PR DESCRIPTION
xroot will come next once https://github.com/xrootd/xrootd/issues/409 is fixed

Test pipeline worked https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/pipelines/849904

BEGINRELEASENOTES
CHANGE: Davix 0.7.2, gfal2 2.16.1, gfal2-python 1.9.5
ENDRELEASENOTES
