### PR TITLE
Add libxcrypt-compat for fedora 30 import test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,7 +131,7 @@ fedora-latest:
   allow_failure: true
   before_script:
     # Needed for ARC
-    - yum install -y libnsl
+    - yum install -y libnsl libxcrypt-compat
 
 ubuntu-latest:
   extends: .run_test


### PR DESCRIPTION
BEGINRELEASENOTES
FIX: Add missing libxcrypt-compat package for import_test.py under Fedora 30

ENDRELEASENOTES
