### PR TITLE
Python requirements, freeze typing module

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -36,6 +36,8 @@ six>=1.10
 sqlalchemy>=1.0.9
 stomp.py>=3.1.5
 suds-jurko>=0.6
+# typing comes in via m2crypto. newer versions of typing caused an error in hypothesis
+typing==3.6.6
 hypothesis
 python-json-logger>=0.1.8
 cx_Oracle


### PR DESCRIPTION

BEGINRELEASENOTES

CHANGE: Freeze the typing module to version 3.6.6., because newer version cause an exception in hypothesis


ENDRELEASENOTES
