### PR TITLE
diracos: set locations of arc and gfal plugins in diracosrc

### DIFF
--- a/diracos/scriptTemplates/diracosrc_tpl.sh
+++ b/diracos/scriptTemplates/diracosrc_tpl.sh
@@ -20,3 +20,16 @@ export PATH
 
 # Silence the python warnings
 export PYTHONWARNINGS="ignore"
+
+# ARC Computing Element
+ARC_PLUGIN_PATH=$DIRACOS/usr/lib64/arc;
+export ARC_PLUGIN_PATH;
+
+# Gfal configuration
+GFAL_CONFIG_DIR=$DIRACOS/etc/gfal2.d;
+export GFAL_CONFIG_DIR;
+
+
+# Gfal plugins
+GFAL_PLUGIN_DIR=$DIRACOS/usr/lib64/gfal2-plugins/;
+export GFAL_PLUGIN_DIR;


### PR DESCRIPTION
Since these plugins are distributed by diracos, it makes sense to set these variables in diracosrc. 
Note that currently they are wrong in the bashrc generated by dirac. PR pending (https://github.com/DIRACGrid/DIRAC/pull/4133)
Test ongoing  https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/pipelines/932269
Fixes  https://github.com/DIRACGrid/DIRACOS/pull/81

BEGINRELEASENOTES
NEW: specify ARC and GFAL plugins locations in diracosrc
ENDRELEASENOTES
