### PR TITLE
Add dependencies for ssh and rrdtools (in tests)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,11 +119,15 @@ SLC6:
   extends: .run_test
   image: cern/slc6-base
   before_script:
-    - yum install tar -y
+    # graphical libraries needed for rrdtool
+    - yum install -y tar freetype fontconfig pixman libXrender
 
 CC7:
   extends: .run_test
   image: cern/cc7-base
+  before_script:
+    # graphical libraries needed for rrdtool
+    - yum install -y freetype fontconfig pixman libXrender
 
 fedora-latest:
   extends: .run_test

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -667,6 +667,11 @@
                {
                   "src": "https://diracos.web.cern.ch/diracos/SRPM/curl-7.19.7-53.el6_9.src.rpm",
                   "name": "curl"
+               },
+               {
+                  "comment": "Needed by ssh for SSHCE",
+                  "src": "https://diracos.web.cern.ch/diracos/SRPM/fipscheck-1.2.0-7.el6.src.rpm",
+                  "name": "fipscheck"
                }
             ]
          },


### PR DESCRIPTION
Tested in https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/pipelines/939150
Addresses https://github.com/DIRACGrid/DIRACOS/issues/83

BEGINRELEASENOTES
FIX: add fipscheck as dependency of ssh
FIX: add graphic libraries to SLC6 & CC7 docker images for rrdtools tests

ENDRELEASENOTES
