### PR TITLE
Change base container to centos6 and enable EPEL

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,11 +42,12 @@ compile:
     - DIRACOS
   except:
     - tags
-  image: cern/slc6-base
+  image: centos:6
   script:
     - source ./docs/Tools/CreateName.sh
     - sed -i "2s/master/${BUILD_NAME}/" config/diracos.json
     - cp config/diracos.json changes/diracos.json
+    - yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-6.noarch.rpm
     - yum install -y mock rpm-build fedora-packager createrepo python-pip
     - export DIRACOS_REPO=/diracos_repo
     - mkdir -p $DIRACOS_REPO/i386 $DIRACOS_REPO/i686 $DIRACOS_REPO/src $DIRACOS_REPO/noarch $DIRACOS_REPO/x86_64 $DIRACOS_REPO/bootstrap $DIRACOS_REPO/buildOnly


### PR DESCRIPTION
This circumvents the CERN repository

BEGINRELEASENOTES

CHANGE: Change base container to centos6 and enable EPEL

ENDRELEASENOTES

Test:https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/pipelines/952846