### PR TITLE
fix version of elasticsearch to less than 7.0.0

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -6,7 +6,7 @@ autopep8==1.3.3
 certifi
 CMRESHandler>=1.0.0b4
 codecov
-elasticsearch-dsl~=6.3.1
+elasticsearch-dsl>=6.0.0,<7.0.0
 fts3-rest
 funcsigs
 future


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: fix version of elasticsearch to less than 7.0.0

ENDRELEASENOTES
