### PR TITLE
Fixes broken tests because of wrong imports

### DIFF
--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -78,7 +78,6 @@ moduleNames = [
     'importlib',
     'inspect',
     'io',
-    'irods',
     'itertools',
     'json',
     'logging',

--- a/tests/integration/test_import.py
+++ b/tests/integration/test_import.py
@@ -94,7 +94,6 @@ moduleNames = [
     'os',
     'os.path',
     'pickle',
-    'pilotTools',
     'pkgutil',
     'platform',
     'pprint',


### PR DESCRIPTION
BEGINRELEASENOTES
CHANGE: Don't test irods import
FIX: Don't test pilotTools import
ENDRELEASENOTES
