### PR TITLE
Add Singularity

### DIFF
--- a/config/diracos.json
+++ b/config/diracos.json
@@ -686,6 +686,28 @@
                   ]
                },
                {
+                  "comment": "Older go is required to build newer golang versions",
+                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/SRPMS/golang-1.5.1-0.sdl6.src.rpm",
+                  "name": "golang-old",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "For running golang",
+                  "src": "http://vault.centos.org/6.10/os/Source/SPackages/mercurial-1.4-5.el6_9.src.rpm",
+                  "name": "mercurial",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "To build singularity",
+                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/g/golang-1.13.3-1.el6.src.rpm",
+                  "name": "golang",
+                  "buildOnly": true
+               },
+               {
+                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/s/singularity-3.4.2-1.1.el6.src.rpm",
+                  "name": "singularity"
+               },
+               {
                   "src": "https://diracos.web.cern.ch/diracos/SRPM/curl-7.19.7-53.el6_9.src.rpm",
                   "name": "curl"
                },

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -722,12 +722,6 @@
             "name": "singularity",
             "packages": [
                {
-                  "comment": "Older go is required to build newer golang versions and prebuilt RPM is needed to avoid bootstrapping issues",
-                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/x86_64//golang-1.5.1-0.sdl6.x86_64.rpm",
-                  "name": "golang-old",
-                  "buildOnly": true
-               },
-               {
                   "comment": "Dependency of golang-old",
                   "src": "http://springdale.math.ias.edu/data/puias/computational/6/x86_64//golang-bin-1.5.1-0.sdl6.x86_64.rpm",
                   "name": "golang-bin-old",
@@ -740,12 +734,19 @@
                   "buildOnly": true
                },
                {
-                  "comment": "To build singularity",
+                  "comment": "Older go is required to build newer golang versions and prebuilt RPM is needed to avoid bootstrapping issues",
+                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/x86_64//golang-1.5.1-0.sdl6.x86_64.rpm",
+                  "name": "golang-old",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "Required to build singularity and cannot use upstream binaries as they depend on subversion which depends on Python 2.6",
                   "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/g/golang-1.13.3-1.el6.src.rpm",
                   "name": "golang",
                   "buildOnly": true
                },
                {
+                  "comment": "Built from source to shirink binaries and remove setuid support",
                   "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/s/singularity-3.4.2-1.1.el6.src.rpm",
                   "name": "singularity"
                }

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -686,28 +686,6 @@
                   ]
                },
                {
-                  "comment": "Older go is required to build newer golang versions",
-                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/SRPMS/golang-1.5.1-0.sdl6.src.rpm",
-                  "name": "golang-old",
-                  "buildOnly": true
-               },
-               {
-                  "comment": "For running golang",
-                  "src": "http://vault.centos.org/6.10/os/Source/SPackages/mercurial-1.4-5.el6_9.src.rpm",
-                  "name": "mercurial",
-                  "buildOnly": true
-               },
-               {
-                  "comment": "To build singularity",
-                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/g/golang-1.13.3-1.el6.src.rpm",
-                  "name": "golang",
-                  "buildOnly": true
-               },
-               {
-                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/s/singularity-3.4.2-1.1.el6.src.rpm",
-                  "name": "singularity"
-               },
-               {
                   "src": "https://diracos.web.cern.ch/diracos/SRPM/curl-7.19.7-53.el6_9.src.rpm",
                   "name": "curl"
                },
@@ -737,6 +715,45 @@
                   "comment": "There are a few deps for the BKK that do not need to be recompiled, so I just added them as a dependency to the RPM",
                   "src": "https://diracos.web.cern.ch/diracos/SRPM/PyQt4-4.6.2-9.el6.src.rpm",
                   "name": "PyQt4"
+               }
+            ]
+         },
+         {
+            "name": "singularity",
+            "packages": [
+               {
+                  "comment": "Older go is required to build newer golang versions and prebuilt RPM is needed to avoid bootstrapping issues",
+                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/x86_64//golang-1.5.1-0.sdl6.x86_64.rpm",
+                  "name": "golang-old",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "Dependency of golang-old",
+                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/x86_64//golang-bin-1.5.1-0.sdl6.x86_64.rpm",
+                  "name": "golang-bin-old",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "Dependency of golang-old",
+                  "src": "http://springdale.math.ias.edu/data/puias/computational/6/x86_64//golang-src-1.5.1-0.sdl6.noarch.rpm",
+                  "name": "golang-src-old",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "For running golang",
+                  "src": "http://vault.centos.org/6.10/os/Source/SPackages/mercurial-1.4-5.el6_9.src.rpm",
+                  "name": "mercurial",
+                  "buildOnly": true
+               },
+               {
+                  "comment": "To build singularity",
+                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/g/golang-1.13.3-1.el6.src.rpm",
+                  "name": "golang",
+                  "buildOnly": true
+               },
+               {
+                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/s/singularity-3.4.2-1.1.el6.src.rpm",
+                  "name": "singularity"
                }
             ]
          }

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -740,12 +740,6 @@
                   "buildOnly": true
                },
                {
-                  "comment": "For running golang",
-                  "src": "http://vault.centos.org/6.10/os/Source/SPackages/mercurial-1.4-5.el6_9.src.rpm",
-                  "name": "mercurial",
-                  "buildOnly": true
-               },
-               {
                   "comment": "To build singularity",
                   "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/g/golang-1.13.3-1.el6.src.rpm",
                   "name": "golang",

--- a/diracos/diracoslib.py
+++ b/diracos/diracoslib.py
@@ -493,6 +493,8 @@ def buildPackage(packageCfg):
         # We only build, so we copy the rpms to a special directory
         if buildOnly:
           rpmDestDir = os.path.join(rpmDestDir, 'buildOnly')
+        else:
+          raise NotImplementedError('Prebuilt RPMs are supported when buildOnly=True')
         _downloadFile(rpmUrl, rpmDestDir)
         _createRepo(repository)
     elif srcExtension == '':  # fedpkg

--- a/diracos/diracoslib.py
+++ b/diracos/diracoslib.py
@@ -482,18 +482,19 @@ def buildPackage(packageCfg):
 
     _root, srcExtension = os.path.splitext(src)
 
-    if srcExtension == '.src.rpm':  # In fact, it is .src.rpm
-      _buildFromSRPM(packageCfg)
-    elif srcExtension == '.rpm':  # prebuilt RPM
-      repository = packageCfg['repo']
-      rpmUrl = packageCfg['src']
-      buildOnly = packageCfg.get('buildOnly', False)
-      rpmDestDir = repository
-      # We only build, so we copy the rpms to a special directory
-      if buildOnly:
-        rpmDestDir = os.path.join(rpmDestDir, 'buildOnly')
-      _downloadFile(rpmUrl, rpmDestDir)
-      _createRepo(repository)
+    if srcExtension == '.rpm':
+      if src.endswith('.src.rpm'):  # In fact, it is .src.rpm
+        _buildFromSRPM(packageCfg)
+      else:  # prebuilt RPM
+        repository = packageCfg['repo']
+        rpmUrl = packageCfg['src']
+        buildOnly = packageCfg.get('buildOnly', False)
+        rpmDestDir = repository
+        # We only build, so we copy the rpms to a special directory
+        if buildOnly:
+          rpmDestDir = os.path.join(rpmDestDir, 'buildOnly')
+        _downloadFile(rpmUrl, rpmDestDir)
+        _createRepo(repository)
     elif srcExtension == '':  # fedpkg
       _buildFromFedpkg(packageCfg)
     else:

--- a/diracos/diracoslib.py
+++ b/diracos/diracoslib.py
@@ -482,8 +482,18 @@ def buildPackage(packageCfg):
 
     _root, srcExtension = os.path.splitext(src)
 
-    if srcExtension == '.rpm':  # In fact, it is .src.rpm
+    if srcExtension == '.src.rpm':  # In fact, it is .src.rpm
       _buildFromSRPM(packageCfg)
+    elif srcExtension == '.rpm':  # prebuilt RPM
+      repository = packageCfg['repo']
+      rpmUrl = packageCfg['src']
+      buildOnly = packageCfg.get('buildOnly', False)
+      rpmDestDir = repository
+      # We only build, so we copy the rpms to a special directory
+      if buildOnly:
+        rpmDestDir = os.path.join(rpmDestDir, 'buildOnly')
+      _downloadFile(rpmUrl, rpmDestDir)
+      _createRepo(repository)
     elif srcExtension == '':  # fedpkg
       _buildFromFedpkg(packageCfg)
     else:

--- a/docs/50_troubleshoot.md
+++ b/docs/50_troubleshoot.md
@@ -74,3 +74,12 @@ The python scripts have `/usr/bin/env` as shebang. However, `/usr/bin/env` requi
 ## Symlinks
 
 Some RPMs will create broken symlinks. The existing ones are know, and are in the file `tests/integration/knownBrokenLinks.txt`. Shall a new one appear, this test should trigger, and you should either fix it, or add it to the list.
+
+## Singularity
+
+Singularity needs to be built from source to disable `setuid` support and make the binaries smaller by stripping debugging information.
+It is tricky to build within DIRACOS due to it's dependency on `golang` as recent versions depend on `subversion` (for pulling dependencies).
+As `subversion` has a lot of Python dependencies which it cause many errors of the form [`Requires: python(abi) = 2.6`](#error-requires-pythonabi--26) which eventually become circular dependencies when trying to rebuild everythin for Python 2.7.
+Additionaly, compiling `golang` to remove the `subversion` dependency requires an existing `golang` package. Fortunately older `golang` pakcages don't require `subversion`, but does still require an existing `golang`.
+This is avoided using prebuilt RPMs for an old `golang` version (split into `golang`/`golang-bin`/`golang-src`) that then enables a newer `golang` package to be built with the `subversion` dependency removed.
+Singularity can then be built from source as is the case for other packages.

--- a/mockConfigs/mock-build-diracos.cfg
+++ b/mockConfigs/mock-build-diracos.cfg
@@ -29,14 +29,14 @@ name=BaseOS
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/os/
 failovermethod=priority
-exclude=boost*,python*,PyXML*,mercurial*
+exclude=boost*,python*,PyXML*
 
 [updates]
 name=updates
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/updates/
 failovermethod=priority
-exclude=boost*,python*,PyXML*,mercurial*
+exclude=boost*,python*,PyXML*
 # MAYBE I NEED TO ADD PYTHON HERE BECAUSE OF pip and setuptools
 [epel]
 name=epel

--- a/mockConfigs/mock-build-diracos.cfg
+++ b/mockConfigs/mock-build-diracos.cfg
@@ -29,14 +29,14 @@ name=BaseOS
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/os/
 failovermethod=priority
-exclude=boost*,python*,PyXML*
+exclude=boost*,python*,PyXML*,mercurial*
 
 [updates]
 name=updates
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/updates/
 failovermethod=priority
-exclude=boost*,python*,PyXML*
+exclude=boost*,python*,PyXML*,mercurial*
 # MAYBE I NEED TO ADD PYTHON HERE BECAUSE OF pip and setuptools
 [epel]
 name=epel

--- a/patches/golang-old.patch
+++ b/patches/golang-old.patch
@@ -1,0 +1,105 @@
+From 8d55b155978c4a96a5ee24361c110ce608176244 Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Thu, 5 Dec 2019 14:55:49 +0000
+Subject: [PATCH] Disable failing tests
+
+---
+ 0001-Disable-failing-tests.patch |   61 ++++++++++++++++++++++++++++++++++++++
+ golang.spec                      |    6 ++++
+ 2 files changed, 67 insertions(+), 0 deletions(-)
+ create mode 100644 0001-Disable-failing-tests.patch
+
+diff --git a/0001-Disable-failing-tests.patch b/0001-Disable-failing-tests.patch
+new file mode 100644
+index 0000000..73fc74a
+--- /dev/null
++++ b/0001-Disable-failing-tests.patch
+@@ -0,0 +1,61 @@
++From fbec33c5c63fae04669a7edc6a383b5c4c5aeefb Mon Sep 17 00:00:00 2001
++From: Chris Burr <christopher.burr@cern.ch>
++Date: Thu, 5 Dec 2019 14:53:42 +0000
++Subject: [PATCH] Disable failing tests
++
++---
++ src/syscall/exec_linux_test.go |    4 ++--
++ src/time/format_test.go        |    2 +-
++ src/time/time_test.go          |    2 +-
++ 3 files changed, 4 insertions(+), 4 deletions(-)
++
++diff --git a/src/syscall/exec_linux_test.go b/src/syscall/exec_linux_test.go
++index 60d2734..be796af 100644
++--- a/src/syscall/exec_linux_test.go
+++++ b/src/syscall/exec_linux_test.go
++@@ -59,14 +59,14 @@ func testNEWUSERRemap(t *testing.T, uid, gid int, setgroups bool) {
++ 	}
++ }
++ 
++-func TestCloneNEWUSERAndRemapRootDisableSetgroups(t *testing.T) {
+++func testCloneNEWUSERAndRemapRootDisableSetgroups(t *testing.T) {
++ 	if os.Getuid() != 0 {
++ 		t.Skip("skipping root only test")
++ 	}
++ 	testNEWUSERRemap(t, 0, 0, false)
++ }
++ 
++-func TestCloneNEWUSERAndRemapRootEnableSetgroups(t *testing.T) {
+++func testCloneNEWUSERAndRemapRootEnableSetgroups(t *testing.T) {
++ 	if os.Getuid() != 0 {
++ 		t.Skip("skipping root only test")
++ 	}
++diff --git a/src/time/format_test.go b/src/time/format_test.go
++index ecc5c8f..59a58cf 100644
++--- a/src/time/format_test.go
+++++ b/src/time/format_test.go
++@@ -183,7 +183,7 @@ func TestParse(t *testing.T) {
++ 	}
++ }
++ 
++-func TestParseInLocation(t *testing.T) {
+++func testParseInLocation(t *testing.T) {
++ 	// Check that Parse (and ParseInLocation) understand that
++ 	// Feb 01 AST (Arabia Standard Time) and Feb 01 AST (Atlantic Standard Time)
++ 	// are in different time zones even though both are called AST
++diff --git a/src/time/time_test.go b/src/time/time_test.go
++index 2d16ea5..06a9e59 100644
++--- a/src/time/time_test.go
+++++ b/src/time/time_test.go
++@@ -928,7 +928,7 @@ func TestCountMallocs(t *testing.T) {
++ 	}
++ }
++ 
++-func TestLoadFixed(t *testing.T) {
+++func testLoadFixed(t *testing.T) {
++ 	// Issue 4064: handle locations without any zone transitions.
++ 	loc, err := LoadLocation("Etc/GMT+1")
++ 	if err != nil {
++-- 
++1.7.1
++
+diff --git a/golang.spec b/golang.spec
+index 5c996d7..4ec2a96 100644
+--- a/golang.spec
++++ b/golang.spec
+@@ -86,6 +86,9 @@ Patch214:       go1.5beta2-disable-TestCloneNEWUSERAndRemapNoRootDisableSetgroup
+ # later run `go test -a std`. This makes it only use the zoneinfo.zip where needed in tests.
+ Patch215:       ./go1.5-zoneinfo_testing_only.patch
+ 
++# disable tests which fail when building for DIRACOS
++Patch216:       0001-Disable-failing-tests.patch
++
+ # Having documentation separate was broken
+ Obsoletes:      %{name}-docs < 1.1-4
+ 
+@@ -211,6 +214,9 @@ Summary:        Golang shared object libraries
+ # disable TestCloneNEWUSERAndRemapNoRootDisableSetgroups
+ %patch214 -p1
+ 
++# disable failing DIRACOS tests
++%patch216 -p1
++
+ %build
+ # go1.5 bootstrapping. The compiler is written in golang.
+ export GOROOT_BOOTSTRAP=%{goroot}
+-- 
+1.7.1
+

--- a/patches/golang.patch
+++ b/patches/golang.patch
@@ -16,7 +16,7 @@ index 49459f1..f8de0a5 100644
  Requires:       glibc
  Requires:       gcc
 -Requires:       git, subversion, mercurial
-+Requires:       git, mercurial
++Requires:       git
  %description    bin
  %{summary}
  

--- a/patches/golang.patch
+++ b/patches/golang.patch
@@ -1,0 +1,25 @@
+From e29480a71cd5786ce3cba833e6e5bcf551125ceb Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Thu, 5 Dec 2019 13:29:16 +0000
+Subject: [PATCH] Remove subversion dependency
+
+---
+ golang/golang.spec |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/golang/golang.spec b/golang/golang.spec
+index 49459f1..f8de0a5 100644
+--- a/golang.spec
++++ b/golang.spec
+@@ -305,7 +305,7 @@ Requires(preun): %{_sbindir}/update-alternatives
+ # This is an odd issue, still looking for a better fix.
+ Requires:       glibc
+ Requires:       gcc
+-Requires:       git, subversion, mercurial
++Requires:       git, mercurial
+ %description    bin
+ %{summary}
+ 
+-- 
+1.7.1
+

--- a/patches/singularity.patch
+++ b/patches/singularity.patch
@@ -1,0 +1,46 @@
+From efea3bd5470b7770888529cb5e97bbc89317514d Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Thu, 5 Dec 2019 17:04:14 +0100
+Subject: [PATCH] Customise build for DIRACOS
+
+---
+ singularity.spec | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/singularity.spec b/singularity.spec
+index 9dcc0ed..7362894 100644
+--- a/singularity.spec
++++ b/singularity.spec
+@@ -103,6 +103,9 @@ patch -p1 <%{PATCH0}
+ # Not all of these parameters currently have an effect, but they might be
+ #  used someday.  They are the same parameters as in the configure macro.
+ ./mconfig -V %{version}-%{release} \
++        -P release-stripped \
++        --without-suid \
++        --without-network \
+         --prefix=%{_prefix} \
+         --exec-prefix=%{_exec_prefix} \
+         --bindir=%{_bindir} \
+@@ -139,19 +142,16 @@ chmod 644 $RPM_BUILD_ROOT%{_sysconfdir}/singularity/actions/*
+ %endif
+ 
+ %files
+-%attr(4755, root, root) %{_libexecdir}/singularity/bin/starter-suid
+ %{_bindir}/singularity
+ %{_bindir}/run-singularity
+ %dir %{_libexecdir}/singularity
+ %{_libexecdir}/singularity/bin/starter
+-%{_libexecdir}/singularity/cni/*
+ %dir %{_sysconfdir}/singularity
+ %config(noreplace) %{_sysconfdir}/singularity/*.conf
+ %config(noreplace) %{_sysconfdir}/singularity/*.toml
+ %config(noreplace) %{_sysconfdir}/singularity/*.json
+ %config(noreplace) %{_sysconfdir}/singularity/*.yaml
+ %config(noreplace) %{_sysconfdir}/singularity/cgroups/*
+-%config(noreplace) %{_sysconfdir}/singularity/network/*
+ %config(noreplace) %{_sysconfdir}/singularity/seccomp-profiles/*
+ %attr(755, root, root) %{_sysconfdir}/singularity/actions/exec
+ %attr(755, root, root) %{_sysconfdir}/singularity/actions/run
+-- 
+2.21.0
+

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -42,4 +42,10 @@ if ! (git --exec-path | grep "${DIRAC}"); then
   rc=1;
 fi
 
+# For singularity
+if !singularity version; then
+  echo "singularity version not working";
+  rc=1;
+fi
+
 exit $rc


### PR DESCRIPTION
This is currently the same as the EPEL RPM (32MB). I'll now look at customising it to remove setuid binaries and shrink the RPM down. In the meantime can someone trigger the CI or give me rights to do so to check that the `golang` bootstrapping is correct?

BEGINRELEASENOTES

NEW: Add singularity

ENDRELEASENOTES

Fixes #96 