### PR TITLE
Update git to 2.18.0

### DIFF
--- a/config/diracos.json
+++ b/config/diracos.json
@@ -129,11 +129,21 @@
                   "buildOnly": true
                },
                {
+                  "comment": "Needed for git",
+                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/p/pcre2-10.21-22.el6.src.rpm",
+                  "name": "pcre2",
+                  "pkgList": [
+                     "pcre2",
+                     "pcre2-devel"
+                  ]
+               },
+               {
                   "comment": "For git python module. We only keep the main module, not all the addons",
                   "src": "https://cbs.centos.org/kojifiles/packages/rh-git218-git/2.18.0/4.el7/src/rh-git218-git-2.18.0-4.el7.src.rpm",
                   "name": "git",
                   "pkgList": [
-                     "git"
+                     "git",
+                     "git-core"
                   ]
                },
                {
@@ -731,6 +741,7 @@
       "initscripts",
       "chkconfig",
       "make",
+      "pcre2-devel",
       "pkgconfig",
       "coreutils",
       "java-1.7.0-oracle-devel",

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -130,7 +130,7 @@
                },
                {
                   "comment": "Needed for git",
-                  "src": "http://download-ib01.fedoraproject.org/pub/epel/6/SRPMS/Packages/p/pcre2-10.21-22.el6.src.rpm",
+                  "src": "https://diracos.web.cern.ch/diracos/SRPM/pcre2-10.21-22.el6.src.rpm",
                   "name": "pcre2",
                   "pkgList": [
                      "pcre2",
@@ -139,7 +139,7 @@
                },
                {
                   "comment": "For git python module. We only keep the main module, not all the addons",
-                  "src": "https://cbs.centos.org/kojifiles/packages/rh-git218-git/2.18.0/4.el7/src/rh-git218-git-2.18.0-4.el7.src.rpm",
+                  "src": "https://diracos.web.cern.ch/diracos/SRPM/rh-git218-git-2.18.0-4.el7.src.rpm",
                   "name": "git",
                   "pkgList": [
                      "git-core"

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -142,7 +142,6 @@
                   "src": "https://cbs.centos.org/kojifiles/packages/rh-git218-git/2.18.0/4.el7/src/rh-git218-git-2.18.0-4.el7.src.rpm",
                   "name": "git",
                   "pkgList": [
-                     "git",
                      "git-core"
                   ]
                },

--- a/config/diracos.json
+++ b/config/diracos.json
@@ -130,7 +130,7 @@
                },
                {
                   "comment": "For git python module. We only keep the main module, not all the addons",
-                  "src": "https://diracos.web.cern.ch/diracos/SRPM/git-1.7.1-9.el6_9.src.rpm",
+                  "src": "https://cbs.centos.org/kojifiles/packages/rh-git218-git/2.18.0/4.el7/src/rh-git218-git-2.18.0-4.el7.src.rpm",
                   "name": "git",
                   "pkgList": [
                      "git"

--- a/diracos/bundlelib.py
+++ b/diracos/bundlelib.py
@@ -105,6 +105,9 @@ def _resolveAllPackageDependencyURLs(requiredPkg=None, ignoredPackages=None):
   # We do not do them all at once, because we would stop at the first one that
   # requires glibc...
   for pkg in requiredPkg:
+    if pkg in ignoredPackages:
+      logging.debug("Skipping %s as it is in ignoredPackages", pkg)
+      continue
     upkg = _unrollPackageDependencies([pkg], ignoredPackages=ignoredPackages)
     logging.debug("%s requires %s", pkg, upkg)
 

--- a/diracos/diracoslib.py
+++ b/diracos/diracoslib.py
@@ -286,6 +286,7 @@ def _buildFromSRPM(packageCfg):
 
   # Get the configuration needed
 
+  dosPkgName = packageCfg['name']
   srpmFile = packageCfg['src']
   repository = packageCfg['repo']
   mockConfig = packageCfg['mockConfig']
@@ -322,8 +323,7 @@ def _buildFromSRPM(packageCfg):
   # If no patchFile is specified but we have a patchDir,
   # try to find a patch file called like the package
   if not patchFile and patchDir:
-
-    potentialPatchFile = os.path.join(patchDir, '%s.patch' % pkgName)
+    potentialPatchFile = os.path.join(patchDir, '%s.patch' % dosPkgName)
     logging.debug("Checking existance of %s", potentialPatchFile)
     if os.path.isfile(potentialPatchFile):
       logging.debug("patch file found")

--- a/patches/git.patch
+++ b/patches/git.patch
@@ -1,14 +1,14 @@
-From 1c26261d3d20f12f3237f9be4ae928d4ef39f5b5 Mon Sep 17 00:00:00 2001
+From 6bb4beda9b09385189bcdf8dff1b57a4220f8421 Mon Sep 17 00:00:00 2001
 From: Chris Burr <christopher.burr@cern.ch>
 Date: Wed, 18 Dec 2019 13:34:37 +0100
 Subject: [PATCH] Patch for DIRACOS
 
 ---
- git.spec | 35 +++++++++--------------------------
- 1 file changed, 9 insertions(+), 26 deletions(-)
+ git.spec | 39 +++++++++++++--------------------------
+ 1 file changed, 13 insertions(+), 26 deletions(-)
 
 diff --git a/git.spec b/git.spec
-index e3db881..aa13f06 100644
+index e3db881..e1d9475 100644
 --- a/git.spec
 +++ b/git.spec
 @@ -197,13 +197,11 @@ BuildRequires:  cvsps
@@ -51,7 +51,18 @@ index e3db881..aa13f06 100644
  %else
  NO_PYTHON = 1
  %endif
-@@ -521,17 +516,15 @@ grep -rlZ '^use Git::LoadCPAN::' | xargs -r0 sed -i 's/Git::LoadCPAN:://g'
+@@ -492,6 +487,10 @@ DEFAULT_TEST_TARGET = prove
+ GIT_PROVE_OPTS = --verbose --normalize %{?_smp_mflags}
+ GIT_TEST_OPTS = -x --verbose-log
+ TEST_SHELL_PATH = /bin/bash
++
++# Enable a relocatable build
++RUNTIME_PREFIX=YesPlease
++PROCFS_EXECUTABLE_PATH=/proc/self/exe
+ EOF
+ 
+ # Filter bogus perl requires
+@@ -521,17 +520,15 @@ grep -rlZ '^use Git::LoadCPAN::' | xargs -r0 sed -i 's/Git::LoadCPAN:://g'
  %build
  %{?scl:scl enable %{scl_httpd} - << "EOF"}
  %{?scl:export CPATH="%{cpath_dir}:${CPATH}"}
@@ -73,7 +84,7 @@ index e3db881..aa13f06 100644
  
  # Fix shebang in a few places to silence rpmlint complaints
  #
-@@ -587,11 +580,6 @@ install -pm 0644 %{SOURCE13} %{buildroot}%{httpdconfdir}/%{?scl_prefix}%{gitweb_
+@@ -587,11 +584,6 @@ install -pm 0644 %{SOURCE13} %{buildroot}%{httpdconfdir}/%{?scl_prefix}%{gitweb_
  sed "s|@PROJECTROOT@|%{_localstatedir}/lib/git|g" \
      %{SOURCE14} > %{buildroot}%{_sysconfdir}/gitweb.conf
  
@@ -85,7 +96,7 @@ index e3db881..aa13f06 100644
  # Clean up contrib/subtree to avoid cruft in the git-core-doc docdir
  # Move git-subtree.txt to Documentation so it can be installed later in docdir
  mv contrib/subtree/git-subtree.txt Documentation/
-@@ -747,16 +735,12 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t9115"
+@@ -747,16 +739,12 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t9115"
  
  export GIT_SKIP_TESTS
  
@@ -105,7 +116,7 @@ index e3db881..aa13f06 100644
  # Run the tests
  %{?scl:scl enable %{scl_httpd} - << "EOF"}
  make test || ./print-failed-test-output
-@@ -777,7 +761,6 @@ make test || ./print-failed-test-output
+@@ -777,7 +765,6 @@ make test || ./print-failed-test-output
  %if %{emacs_filesystem}
  %{elispdir}
  %endif
@@ -113,7 +124,7 @@ index e3db881..aa13f06 100644
  %{_datadir}/git-core/contrib/hooks/multimail
  %{_datadir}/git-core/contrib/hooks/update-paranoid
  %{_datadir}/git-core/contrib/hooks/setgitperms.perl
-@@ -794,7 +777,6 @@ make test || ./print-failed-test-output
+@@ -794,7 +781,6 @@ make test || ./print-failed-test-output
  %{!?_licensedir:%global license %doc}
  %license COPYING
  # exclude is best way here because of troubles with symlinks inside git-core/
@@ -121,7 +132,7 @@ index e3db881..aa13f06 100644
  %exclude %{_datadir}/git-core/contrib/hooks/multimail
  %exclude %{_datadir}/git-core/contrib/hooks/update-paranoid
  %exclude %{_datadir}/git-core/contrib/hooks/setgitperms.perl
-@@ -2234,3 +2216,4 @@ make test || ./print-failed-test-output
+@@ -2234,3 +2220,4 @@ make test || ./print-failed-test-output
  
  * Thu Jul 7 2005 Chris Wright <chris@osdl.org>
  - initial git spec file

--- a/patches/git.patch
+++ b/patches/git.patch
@@ -1,0 +1,98 @@
+From bc6f6f99eba96f892e84e20ef8089a8f24ba1538 Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Wed, 18 Dec 2019 13:34:37 +0100
+Subject: [PATCH] Patch for DIRACOS
+
+---
+ git.spec | 27 ++++++++++-----------------
+ 1 file changed, 10 insertions(+), 17 deletions(-)
+
+diff --git a/git.spec b/git.spec
+index e3db881..d9fda66 100644
+--- a/git.spec
++++ b/git.spec
+@@ -203,7 +203,6 @@ BuildRequires:  httpd
+ %if 0%{?fedora} && %{_arch} != s390x
+ BuildRequires:  jgit
+ %endif
+-BuildRequires:  mod_dav_svn
+ BuildRequires:  pcre
+ BuildRequires:  perl(App::Prove)
+ BuildRequires:  perl(CGI)
+@@ -223,8 +222,6 @@ BuildRequires:  python2-devel
+ %if %{with python3}
+ BuildRequires:  python3-devel
+ %endif
+-BuildRequires:  subversion
+-BuildRequires:  subversion-perl
+ BuildRequires:  time
+ 
+ Requires:       %{?scl_prefix}git-core = %{version}-%{release}
+@@ -264,7 +261,6 @@ Requires:       %{?scl_prefix}git-gui = %{version}-%{release}
+ Requires:       %{?scl_prefix}git-p4 = %{version}-%{release}
+ %endif
+ Requires:       %{?scl_prefix}git-subtree = %{version}-%{release}
+-Requires:       %{?scl_prefix}git-svn = %{version}-%{release}
+ Requires:       %{?scl_prefix}gitk = %{version}-%{release}
+ Requires:       %{?scl_prefix}perl-Git = %{version}-%{release}
+ %if ! %{defined perl_bootstrap}
+@@ -478,7 +474,7 @@ GITWEB_PROJECTROOT = %{_localstatedir}/lib/git
+ GNU_ROFF = 1
+ NO_PERL_CPAN_FALLBACKS = 1
+ %if %{with python2}
+-PYTHON_PATH = %{__python2}
++PYTHON_PATH = /usr/bin/python2.7
+ %else
+ NO_PYTHON = 1
+ %endif
+@@ -521,17 +517,17 @@ grep -rlZ '^use Git::LoadCPAN::' | xargs -r0 sed -i 's/Git::LoadCPAN:://g'
+ %build
+ %{?scl:scl enable %{scl_httpd} - << "EOF"}
+ %{?scl:export CPATH="%{cpath_dir}:${CPATH}"}
+-%make_build all %{?with_docs:doc}
++make %{?_smp_mflags} all %{?with_docs:doc}
+ 
+-%make_build -C contrib/contacts/ all %{?with_docs:doc}
++make %{?_smp_mflags} -C contrib/contacts/ all %{?with_docs:doc}
+ 
+ %if %{libsecret}
+-%make_build -C contrib/credential/libsecret/
++make %{?_smp_mflags} -C contrib/credential/libsecret/
+ %endif
+ 
+-%make_build -C contrib/diff-highlight/
++make %{?_smp_mflags} -C contrib/diff-highlight/
+ 
+-%make_build -C contrib/subtree/ all %{?with_docs:doc}
++make %{?_smp_mflags} -C contrib/subtree/ all %{?with_docs:doc}
+ 
+ # Fix shebang in a few places to silence rpmlint complaints
+ #
+@@ -747,16 +743,12 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t9115"
+ 
+ export GIT_SKIP_TESTS
+ 
++# Subversion support has been explicitly removed from DIRACOS
++export NO_SVN_TESTS=1
++
+ # Set LANG so various UTF-8 tests are run
+ export LANG=en_US.UTF-8
+ 
+-# Explicitly enable tests which may be skipped opportunistically
+-# (Check for variables set via test_tristate in the test suite)
+-export GIT_SVN_TEST_HTTPD=true
+-export GIT_TEST_GIT_DAEMON=true
+-export GIT_TEST_HTTPD=true
+-export GIT_TEST_SVNSERVE=true
+-
+ # Run the tests
+ %{?scl:scl enable %{scl_httpd} - << "EOF"}
+ make test || ./print-failed-test-output
+@@ -2234,3 +2226,4 @@ make test || ./print-failed-test-output
+ 
+ * Thu Jul 7 2005 Chris Wright <chris@osdl.org>
+ - initial git spec file
++-
+-- 
+2.21.0
+

--- a/patches/git.patch
+++ b/patches/git.patch
@@ -1,17 +1,23 @@
-From bc6f6f99eba96f892e84e20ef8089a8f24ba1538 Mon Sep 17 00:00:00 2001
+From 1c26261d3d20f12f3237f9be4ae928d4ef39f5b5 Mon Sep 17 00:00:00 2001
 From: Chris Burr <christopher.burr@cern.ch>
 Date: Wed, 18 Dec 2019 13:34:37 +0100
 Subject: [PATCH] Patch for DIRACOS
 
 ---
- git.spec | 27 ++++++++++-----------------
- 1 file changed, 10 insertions(+), 17 deletions(-)
+ git.spec | 35 +++++++++--------------------------
+ 1 file changed, 9 insertions(+), 26 deletions(-)
 
 diff --git a/git.spec b/git.spec
-index e3db881..d9fda66 100644
+index e3db881..aa13f06 100644
 --- a/git.spec
 +++ b/git.spec
-@@ -203,7 +203,6 @@ BuildRequires:  httpd
+@@ -197,13 +197,11 @@ BuildRequires:  cvsps
+ %endif
+ BuildRequires:  gnupg
+ %if 0%{?fedora} || ( 0%{?rhel} && ( 0%{?rhel} == 6 || 0%{?rhel} >= 7 && %{_arch} != ppc64 ))
+-BuildRequires:  highlight
+ %endif
+ BuildRequires:  httpd
  %if 0%{?fedora} && %{_arch} != s390x
  BuildRequires:  jgit
  %endif
@@ -19,7 +25,7 @@ index e3db881..d9fda66 100644
  BuildRequires:  pcre
  BuildRequires:  perl(App::Prove)
  BuildRequires:  perl(CGI)
-@@ -223,8 +222,6 @@ BuildRequires:  python2-devel
+@@ -223,8 +221,6 @@ BuildRequires:  python2-devel
  %if %{with python3}
  BuildRequires:  python3-devel
  %endif
@@ -28,7 +34,7 @@ index e3db881..d9fda66 100644
  BuildRequires:  time
  
  Requires:       %{?scl_prefix}git-core = %{version}-%{release}
-@@ -264,7 +261,6 @@ Requires:       %{?scl_prefix}git-gui = %{version}-%{release}
+@@ -264,7 +260,6 @@ Requires:       %{?scl_prefix}git-gui = %{version}-%{release}
  Requires:       %{?scl_prefix}git-p4 = %{version}-%{release}
  %endif
  Requires:       %{?scl_prefix}git-subtree = %{version}-%{release}
@@ -36,7 +42,7 @@ index e3db881..d9fda66 100644
  Requires:       %{?scl_prefix}gitk = %{version}-%{release}
  Requires:       %{?scl_prefix}perl-Git = %{version}-%{release}
  %if ! %{defined perl_bootstrap}
-@@ -478,7 +474,7 @@ GITWEB_PROJECTROOT = %{_localstatedir}/lib/git
+@@ -478,7 +473,7 @@ GITWEB_PROJECTROOT = %{_localstatedir}/lib/git
  GNU_ROFF = 1
  NO_PERL_CPAN_FALLBACKS = 1
  %if %{with python2}
@@ -45,7 +51,7 @@ index e3db881..d9fda66 100644
  %else
  NO_PYTHON = 1
  %endif
-@@ -521,17 +517,17 @@ grep -rlZ '^use Git::LoadCPAN::' | xargs -r0 sed -i 's/Git::LoadCPAN:://g'
+@@ -521,17 +516,15 @@ grep -rlZ '^use Git::LoadCPAN::' | xargs -r0 sed -i 's/Git::LoadCPAN:://g'
  %build
  %{?scl:scl enable %{scl_httpd} - << "EOF"}
  %{?scl:export CPATH="%{cpath_dir}:${CPATH}"}
@@ -61,14 +67,25 @@ index e3db881..d9fda66 100644
  %endif
  
 -%make_build -C contrib/diff-highlight/
-+make %{?_smp_mflags} -C contrib/diff-highlight/
- 
+-
 -%make_build -C contrib/subtree/ all %{?with_docs:doc}
 +make %{?_smp_mflags} -C contrib/subtree/ all %{?with_docs:doc}
  
  # Fix shebang in a few places to silence rpmlint complaints
  #
-@@ -747,16 +743,12 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t9115"
+@@ -587,11 +580,6 @@ install -pm 0644 %{SOURCE13} %{buildroot}%{httpdconfdir}/%{?scl_prefix}%{gitweb_
+ sed "s|@PROJECTROOT@|%{_localstatedir}/lib/git|g" \
+     %{SOURCE14} > %{buildroot}%{_sysconfdir}/gitweb.conf
+ 
+-# install contrib/diff-highlight and clean up to avoid cruft in git-core-doc
+-install -Dpm 0755 contrib/diff-highlight/diff-highlight \
+-    %{buildroot}%{_datadir}/git-core/contrib/diff-highlight
+-rm -rf contrib/diff-highlight/{Makefile,diff-highlight,*.perl,t}
+-
+ # Clean up contrib/subtree to avoid cruft in the git-core-doc docdir
+ # Move git-subtree.txt to Documentation so it can be installed later in docdir
+ mv contrib/subtree/git-subtree.txt Documentation/
+@@ -747,16 +735,12 @@ GIT_SKIP_TESTS="$GIT_SKIP_TESTS t9115"
  
  export GIT_SKIP_TESTS
  
@@ -88,7 +105,23 @@ index e3db881..d9fda66 100644
  # Run the tests
  %{?scl:scl enable %{scl_httpd} - << "EOF"}
  make test || ./print-failed-test-output
-@@ -2234,3 +2226,4 @@ make test || ./print-failed-test-output
+@@ -777,7 +761,6 @@ make test || ./print-failed-test-output
+ %if %{emacs_filesystem}
+ %{elispdir}
+ %endif
+-%{_datadir}/git-core/contrib/diff-highlight
+ %{_datadir}/git-core/contrib/hooks/multimail
+ %{_datadir}/git-core/contrib/hooks/update-paranoid
+ %{_datadir}/git-core/contrib/hooks/setgitperms.perl
+@@ -794,7 +777,6 @@ make test || ./print-failed-test-output
+ %{!?_licensedir:%global license %doc}
+ %license COPYING
+ # exclude is best way here because of troubles with symlinks inside git-core/
+-%exclude %{_datadir}/git-core/contrib/diff-highlight
+ %exclude %{_datadir}/git-core/contrib/hooks/multimail
+ %exclude %{_datadir}/git-core/contrib/hooks/update-paranoid
+ %exclude %{_datadir}/git-core/contrib/hooks/setgitperms.perl
+@@ -2234,3 +2216,4 @@ make test || ./print-failed-test-output
  
  * Thu Jul 7 2005 Chris Wright <chris@osdl.org>
  - initial git spec file

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -8,52 +8,32 @@
 scriptsToTest=(mysql gfal-ls gfal-stat myproxy-info voms-proxy-init2 rrdtool);
 rc=0
 
-for script in ${scriptsToTest[@]};
-do
+for script in "${scriptsToTest[@]}"; do
    # Try --help first
-   ${script} --help &>/dev/null;
-   if [ $? -ne 0 ];
-   then
+   if ! ${script} --help &>/dev/null; then
      # Try just -h
-     ${script} -h &>/dev/null;
-     # If it still fails, try with no options
-     if [ $? -ne 0 ];
-     then
-       ${script}  &>/dev/null;
-       # If it still fails, it fails...
-       if [ $? -ne 0 ];
-       then
-         echo "$script seems not to be working"
+     if ! ${script} -h &>/dev/null; then
+      # If it still fails, try with no options
+       if ! ${script}  &>/dev/null; then
+         # If it still fails, it fails...
          rc=1;
        fi
      fi
    fi
 done
 
-
 # Now some specific tests that do not behave like the other binaries
 
 # For BDDI and ARC
-
-ldapsearch --help 2>&1 >/dev/null | grep -q "usage: ldapsearch";
-
-if [ $? -ne 0 ];
-then
+if ! (ldapsearch --help 2>&1 >/dev/null | grep -q "usage: ldapsearch"); then
   echo "ldapsearch not working";
   rc=1;
 fi
 
-
 # For SSHComputingElement
-
-ssh --help 2>&1 >/dev/null | grep -q "usage:";
-
-if [ $? -ne 0 ];
-then
+if ! (ssh --help 2>&1 >/dev/null | grep -q "usage:"); then
   echo "ssh not working";
   rc=1;
 fi
-
-
 
 exit $rc

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -36,4 +36,9 @@ if ! (ssh --help 2>&1 >/dev/null | grep -q "usage:"); then
   rc=1;
 fi
 
+# For https://github.com/DIRACGrid/DIRACOS/issues/107
+if ! (git --exec-path | grep "${DIRAC}"); then
+  echo "git --exec-path does not contain ${DIRAC}";
+fi
+
 exit $rc

--- a/tests/integration/test_cli.sh
+++ b/tests/integration/test_cli.sh
@@ -39,6 +39,7 @@ fi
 # For https://github.com/DIRACGrid/DIRACOS/issues/107
 if ! (git --exec-path | grep "${DIRAC}"); then
   echo "git --exec-path does not contain ${DIRAC}";
+  rc=1;
 fi
 
 exit $rc


### PR DESCRIPTION
Closes #107 by updating git and making it a procfs relocatable build.

Tested in https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/pipelines/1310581.

BEGINRELEASENOTES

CHANGE: Update git to 2.18.0
FIX: Remove dependency on host git installation by making git relocatable
FIX:  Don't bundle entries listed in `ignoredPackages`

ENDRELEASENOTES
