### PR TITLE
Fix stomp.py version to 4.1.22 as further releases are python 3 only

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -37,7 +37,8 @@ rst2pdf>=0.93
 simplejson>=3.8.1
 six>=1.10
 sqlalchemy>=1.0.9
-stomp.py>=3.1.5
+# More recent version of stomp are python 3 only
+stomp.py==4.1.22
 subprocess32
 suds-jurko>=0.6
 # typing comes in via m2crypto. newer versions of typing caused an error in hypothesis


### PR DESCRIPTION
Tests are currently failing with
```
----------------------------- Captured stderr call -----------------------------
Traceback (most recent call last):
  File "/builds/CLICdp/iLCDirac/DIRACOS/tests/integration/test_import.py", line 182, in test_module
    module = __import__(moduleName)
  File "/tmp/diracos/usr/lib64/python2.7/site-packages/stomp/__init__.py", line 15, in <module>
    import stomp.connect as connect
  File "/tmp/diracos/usr/lib64/python2.7/site-packages/stomp/connect.py", line 8, in <module>
    from stomp.protocol import *
  File "/tmp/diracos/usr/lib64/python2.7/site-packages/stomp/protocol.py", line 6, in <module>
    from stomp.listener import *
  File "/tmp/diracos/usr/lib64/python2.7/site-packages/stomp/listener.py", line 9, in <module>
    from time import monotonic
ImportError: cannot import name monotonic
=============== 1 failed, 119 passed, 1 skipped in 4.62 seconds ================
```
This is because `stomp.py` recent releases are python 3 only. This freezes the versin

BEGINRELEASENOTES
CHANGE: Freeze stomp.py to 4.1.22

ENDRELEASENOTES
