### PR TITLE
Add integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -161,12 +161,72 @@ fedora-latest:
     # https://bugzilla.redhat.com/show_bug.cgi?id=1694850
     - export OPENSSL_CONF=/etc/pki/openssl10.cnf
 
-
-
 ubuntu-latest:
   extends: .run_test
   image: ubuntu:latest
   allow_failure: true
+
+.integration_tests:
+  stage: test
+  dependencies:
+    - compile
+  tags:
+    - DIRACOS
+  image: diracgrid/docker-compose-dirac:latest
+  before_script:
+    - source ./docs/Tools/CreateName.sh
+
+    # Clone DIRAC
+    - git clone https://github.com/DIRACGrid/DIRAC.git
+    - cd DIRAC
+    - git checkout "${DIRAC_RELEASE}"
+    - cd ..
+    # Set environment variables
+    - export CI_REGISTRY_IMAGE=diracgrid
+    - export HOST_OS=${HOST_OS}
+    - export CI_PROJECT_DIR=${PWD}/DIRAC
+    - export CI_COMMIT_REF_NAME=refs/heads/${DIRAC_RELEASE}
+    - export MYSQL_VER=${MYSQL_VER}
+    - export ES_VER=${ES_VER}
+    - export DIRACOSVER=${BUILD_NAME}
+    - export DIRACOS_TARBALL_PATH="/"
+    # Prepare for docker in docker
+    - unset DOCKER_HOST
+    - mkdir -p $PWD/docker-data /var/lib
+    - ln -s $PWD/docker-data /var/lib/docker
+    - apk add --no-cache btrfs-progs e2fsprogs e2fsprogs-extra iptables openssl shadow-uidmap xfsprogs xz pigz
+    - dockerd >/dev/null 2>&1 &
+    - sleep 10
+    # Activate the DIRAC testing environment
+    - source DIRAC/tests/CI/run_docker_setup.sh
+    - prepareEnvironment
+    # Copy the DIRAC OS tarball into the containers
+    - docker cp "${CI_PROJECT_DIR}/../public/releases/diracos-${BUILD_NAME}.tar.gz" server:/
+    - docker cp "${CI_PROJECT_DIR}/../public/releases/diracos-${BUILD_NAME}.md5" server:/
+    - docker exec -u root server chown dirac /diracos-${BUILD_NAME}.{tar.gz,md5}
+    - docker cp "${CI_PROJECT_DIR}/../public/releases/diracos-${BUILD_NAME}.tar.gz" client:/
+    - docker cp "${CI_PROJECT_DIR}/../public/releases/diracos-${BUILD_NAME}.md5" client:/
+    - docker exec -u root client chown dirac /diracos-${BUILD_NAME}.{tar.gz,md5}
+  script:
+    - installServer
+    - installClient
+    - testServer
+    - testClient
+    - checkErrors
+
+integration_tests_slc6:
+  extends: .integration_tests
+  variables:
+    MYSQL_VER: "5.7"
+    HOST_OS: slc6
+    DIRAC_RELEASE: master
+
+integration_tests_cc7:
+  extends: .integration_tests
+  variables:
+    MYSQL_VER: "5.7"
+    HOST_OS: cc7
+    DIRAC_RELEASE: master
 
 ########### CHRIS
 # Run the dyn tests as a separate test for the time being, so to allow it to fail


### PR DESCRIPTION
Closes #106.

Depends on https://github.com/DIRACGrid/management/pull/1 and https://github.com/DIRACGrid/DIRAC/pull/4409.

BEGINRELEASENOTES

NEW: Run DIRAC integration tests with the tarball
FIX: Use latest pip inside the virtual environment so `python_version` metadata is considered

ENDRELEASENOTES
