### PR TITLE
DIRACOS: proper versions.txt generated for extension builds

### DIFF
--- a/diracos/scriptTemplates/build_diracos_extension_tpl.sh
+++ b/diracos/scriptTemplates/build_diracos_extension_tpl.sh
@@ -76,7 +76,7 @@ echo -e "$EXTENSION_NAME""DIRACOS $DIRACOS_EXT_VERSION $(date -u) based on DIRAC
 
 echo -e "===== Python packages ====\n\n" >> $DIRACOS_EXT_VERSION_FILE
 # reminder: this file was generated when building the python modules
-comm -3 before.txt after.txt | sed 's/\t//g' | sort >> $DIRACOS_EXT_VERSION_FILE
+comm -13 before.txt after.txt | sed 's/\t//g' | sort >> $DIRACOS_EXT_VERSION_FILE
 
 # Remove pyo and pyc
 find $DIRACOS_PATH -name '*.py[oc]' -exec rm {} \;


### PR DESCRIPTION
The comparison was wrong, which led into almost duplicate line when upgrading a package in an extension, for example:
```
===== Python packages ====

LbEnv==1.1.6

LbPlatformUtils==4.3.1

awkward==0.12.19

awkward==0.12.20

uproot-methods==0.7.2

uproot-methods==0.7.3

uproot==3.11.1

uproot==3.11.2

xenv==0.0.4
```
BEGINRELEASENOTES

FIX: fix the generation of the version file for the extension build

ENDRELEASENOTES
