### PR TITLE
Keep empty directory in the bundling

### DIFF
--- a/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
+++ b/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
@@ -30,9 +30,6 @@ echo "Copying python modules"
 rsync -zvr /tmp/pipDirac/lib/ $DIRACOS/usr/lib64/
 cp -r /tmp/pipDirac/bin/ $DIRACOS/usr/
 
-echo "Deleting empty directories"
-find $DIRACOS -type d -empty -delete
-
 # Fix the shebang for python
 echo "Fixing the shebang"
 grep -rIl '#!/usr/bin/python' /tmp/diracos | xargs sed -i 's:#!/usr/bin/python:#!/usr/bin/env python:g'


### PR DESCRIPTION
That bloody singularity expects a directory to be here, which of course we prune.
So do not remove unused useless empty directory...

BEGINRELEASENOTES

CHANGE: Keep empty directory because of idiotic singularity

ENDRELEASENOTES
