### PR TITLE
Remove rst2pdf from the dependencies

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -20,6 +20,7 @@ MySQL-python>=1.2.5
 jinja2
 ipython==5.3.0
 numpy>=1.10.1
+pillow
 pexpect>=4.0.1
 psutil>=4.2.0
 pyasn1>0.4.1

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -6,6 +6,7 @@ autopep8==1.3.3
 certifi
 CMRESHandler>=1.0.0b4
 codecov
+docutils
 elasticsearch-dsl>=6.0.0,<7.0.0
 fts3-rest
 funcsigs

--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -33,7 +33,6 @@ pytest-mock
 pytz>=2015.7
 readline>=6.2.4
 requests>=2.9.1
-rst2pdf>=0.93
 simplejson>=3.8.1
 six>=1.10
 sqlalchemy>=1.0.9


### PR DESCRIPTION
This library is used only by dirac-create-distribution-tarball in DIRAC, not the one in management

BEGINRELEASENOTES
CHANGE: remove rst2pdf and add Pillow and docutils
ENDRELEASENOTES

@chrisburr  @petricm this is what was making the build fail (at least, one of its dependency)
@fstagni @atsareg FYI 