### PR TITLE
Add boto3 as requirements

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -3,6 +3,7 @@ git+https://github.com/DIRACGrid/pyGSI.git#egg=GSI
 
 # From pypi
 autopep8==1.3.3
+boto3
 certifi
 CMRESHandler>=1.0.0b4
 codecov


### PR DESCRIPTION
Needed for S3 support
BEGINRELEASENOTES
NEW: Add boto3 as requirements (for S3)
ENDRELEASENOTES
