### PR TITLE
Exclude docs from testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -274,7 +274,6 @@ dyn_SLC6:
   before_script:
     # graphical libraries needed for rrdtool
     - yum install -y tar freetype fontconfig pixman libXrender unzip
-  allow_failure: true
 
 dyn_CC7:
   extends: .run_dyn_test
@@ -282,7 +281,6 @@ dyn_CC7:
   before_script:
     # graphical libraries needed for rrdtool
     - yum install -y freetype fontconfig pixman libXrender unzip
-  allow_failure: true
 
 #######################################################################################
 

--- a/tests/integration/test_dyn_import.py
+++ b/tests/integration/test_dyn_import.py
@@ -7,7 +7,6 @@ import os
 import traceback
 import warnings
 import pytest
-import sys
 import findimports
 
 parametrize = pytest.mark.parametrize
@@ -23,8 +22,15 @@ diracPath = os.environ['DIRAC']
 
 # Find all the packages used by DIRAC
 g = findimports.ModuleGraph()
-g.parsePathname(diracPath)
-# g.parsePathname('/tmp/cacheFile.importcache')
+directories = next(os.walk(diracPath))[1]
+directories.remove('docs')
+
+for dir in directories:
+  g.parsePathname('%s/%s' % (diracPath, dir))
+
+g.parseFile('%s/%s' % (diracPath, '__init__.py'))
+g.parseFile('%s/%s' % (diracPath, 'setup.py'))
+
 g = g.packageGraph(packagelevel=1).collapseTests()
 moduleNames = set([i for m in g.listModules() for i in m.imports])
 


### PR DESCRIPTION
BEGINRELEASENOTES
NEW: Exclude `docs` folder dyn import test
CHANGE: Require python imports tests to pass in CI

ENDRELEASENOTES
