### PR TITLE
exclude firefox from mock config repos

### DIFF
--- a/mockConfigs/mock-build-diracos.cfg
+++ b/mockConfigs/mock-build-diracos.cfg
@@ -29,20 +29,20 @@ name=BaseOS
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/os/
 failovermethod=priority
-exclude=boost*,python*,PyXML*
+exclude=boost*,python*,PyXML*,firefox*
 
 [updates]
 name=updates
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/updates/
 failovermethod=priority
-exclude=boost*,python*,PyXML*
+exclude=boost*,python*,PyXML*,firefox*
 # MAYBE I NEED TO ADD PYTHON HERE BECAUSE OF pip and setuptools
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,firefox*
 enabled=0
 
 [testing]
@@ -50,7 +50,7 @@ name=epel-testing
 enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,firefox*
 
 [epel-debug]
 name=epel-debug

--- a/mockConfigs/mock-build-diracos.cfg
+++ b/mockConfigs/mock-build-diracos.cfg
@@ -29,20 +29,20 @@ name=BaseOS
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/os/
 failovermethod=priority
-exclude=boost*,python*,PyXML*,firefox*
+exclude=boost*,python*,PyXML*,firefox*,thunderbird*
 
 [updates]
 name=updates
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/updates/
 failovermethod=priority
-exclude=boost*,python*,PyXML*,firefox*
+exclude=boost*,python*,PyXML*,firefox*,thunderbird*
 # MAYBE I NEED TO ADD PYTHON HERE BECAUSE OF pip and setuptools
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,firefox*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,firefox*,thunderbird*
 enabled=0
 
 [testing]
@@ -50,7 +50,7 @@ name=epel-testing
 enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*,firefox*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,firefox*,thunderbird*
 
 [epel-debug]
 name=epel-debug

--- a/mockConfigs/mock-install-diracos.cfg
+++ b/mockConfigs/mock-install-diracos.cfg
@@ -30,20 +30,20 @@ name=BaseOS
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/os/
 failovermethod=priority
-exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,firefox*
+exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,firefox*,thunderbird*
 
 [updates]
 name=updates
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/updates/
 failovermethod=priority
-exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,yum-utils*,firefox*
+exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,yum-utils*,firefox*,thunderbird*
 # MAYBE I NEED TO ADD PYTHON HERE BECAUSE OF pip and setuptools
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,glite*,xroot*,davix*,nordugrid*,firefox*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,glite*,xroot*,davix*,nordugrid*,firefox*,thunderbird*
 enabled=0
 
 [testing]
@@ -51,7 +51,7 @@ name=epel-testing
 enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*,firefox*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,firefox*,thunderbird*
 
 [epel-debug]
 name=epel-debug

--- a/mockConfigs/mock-install-diracos.cfg
+++ b/mockConfigs/mock-install-diracos.cfg
@@ -30,20 +30,20 @@ name=BaseOS
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/os/
 failovermethod=priority
-exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*
+exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,firefox*
 
 [updates]
 name=updates
 enabled=1
 baseurl=http://linuxsoft.cern.ch/cern/slc6X/x86_64/yum/updates/
 failovermethod=priority
-exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,yum-utils*
+exclude=boost*,libxml*,python*,python-setuptools*,mysql*,libcurl*,curl*,yum-utils*,firefox*
 # MAYBE I NEED TO ADD PYTHON HERE BECAUSE OF pip and setuptools
 [epel]
 name=epel
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=epel-6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,glite*,xroot*,davix*,nordugrid*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,globus*,glite*,xroot*,davix*,nordugrid*,firefox*
 enabled=0
 
 [testing]
@@ -51,7 +51,7 @@ name=epel-testing
 enabled=0
 mirrorlist=http://mirrors.fedoraproject.org/mirrorlist?repo=testing-epel6&arch=x86_64
 failovermethod=priority
-exclude=epel-release*,epel-rpm-macros*,gfal2*
+exclude=epel-release*,epel-rpm-macros*,gfal2*,firefox*
 
 [epel-debug]
 name=epel-debug


### PR DESCRIPTION
Firefox and Thunderbird started to bundle many libs instead of using system ones.
BEGINRELEASENOTES
FIX: Remove firefox from mockConfig repo configuration not to interfere with builds

ENDRELEASENOTES
Resolves #148 