### PR TITLE
add flaky to requirements.txt

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -10,6 +10,7 @@ codecov
 diraccfg
 docutils
 elasticsearch-dsl>=6.0.0,<7.0.0
+flaky
 fts3-rest
 funcsigs
 future


### PR DESCRIPTION
BEGINRELEASENOTES
NEW: add flaky to python packages needed by DIRACGrid/DIRAC#4732



ENDRELEASENOTES
