### PR TITLE
Fix M2Crypto to 0.36 due to swig problem in future versions

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -23,7 +23,7 @@ ldap3
 # newer versions of matplotlib require python 3
 matplotlib>=2.1.0,<3.0
 mock>=1.0.1
-M2Crypto
+M2Crypto==0.36
 MySQL-python>=1.2.5
 jinja2
 ipython==5.3.0


### PR DESCRIPTION
BEGINRELEASENOTES

FIX: Fix M2Crypto to 0.36 due to swig problem in future versions

ENDRELEASENOTES
