### PR TITLE
Get get-pip.py from dirac server

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -316,8 +316,8 @@ push_tag:
     GIT_STRATEGY: none
   image: cern/cc7-base
   before_script:
-    - curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-    - python get-pip.py
+    - curl -O -L https://diracos.web.cern.ch/diracos/bootstrap/get-pip.py
+    - python get-pip.py pip==20.2.4
     - pip install -U requests python-dateutil pytz
     - yum install git less -y
     - eval `ssh-agent -s`

--- a/diracos/scriptTemplates/build_python_module_tpl.sh
+++ b/diracos/scriptTemplates/build_python_module_tpl.sh
@@ -29,7 +29,7 @@ source $PIP_DIRAC/bin/activate
 
 echo "Installing newer pip in virtualenv"
 cd /tmp
-curl -O -L https://bootstrap.pypa.io/get-pip.py
+curl -O -L https://diracos.web.cern.ch/diracos/bootstrap/get-pip.py
 python get-pip.py pip==20.2.4
 
 pip install -r /tmp/requirements.txt

--- a/diracos/scriptTemplates/fix_pip_requirements_versions_tpl.sh
+++ b/diracos/scriptTemplates/fix_pip_requirements_versions_tpl.sh
@@ -24,7 +24,7 @@ if [ ! -z "$PIP_BUILD_DEPENDENCIES" ];
 then
   echo "Installing pip"
   cd /tmp
-  curl -O -L https://bootstrap.pypa.io/get-pip.py
+  curl -O -L https://diracos.web.cern.ch/diracos/bootstrap/get-pip.py
   python get-pip.py pip==20.2.4
 
   echo "Installing pip-tools"


### PR DESCRIPTION
BEGINRELEASENOTES

FIX: get the last python2 compatible pip bootstrap script from the diracos server

ENDRELEASENOTES
