### PR TITLE
Add libcloud for VMDIRAC

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -4,6 +4,7 @@ git+https://github.com/DIRACGrid/tornado.git@iostreamConfigurable
 git+https://github.com/DIRACGrid/tornado_m2crypto.git
 
 # From pypi
+apache-libcloud
 autopep8==1.3.3
 boto3
 certifi


### PR DESCRIPTION
Hi,

Can we please add apache-libcloud to the requirements list? It's used by some of the resource plug-ins in VMDIRAC and asking admins to pip install it on every upgrade isn't very neat.

Regards,
Simon

BEGINRELEASENOTES
NEW: add apache-libcloud for VMDIRAC
ENDRELEASENOTES
