### PR TITLE
diracosrc: add DAVIX_USE_LIBCURL=1

### DIFF
--- a/diracos/scriptTemplates/diracosrc_tpl.sh
+++ b/diracos/scriptTemplates/diracosrc_tpl.sh
@@ -30,6 +30,9 @@ export GFAL_CONFIG_DIR;
 GFAL_PLUGIN_DIR=$DIRACOS/usr/lib64/gfal2-plugins/;
 export GFAL_PLUGIN_DIR;
 
+# Davix options (will be default in the future)
+export DAVIX_USE_LIBCURL=1
+
 # Many Linux distributions set LESSOPEN to provide fancier features
 # These don't work with the CentOS 6 version of less so unset the variable
 unset LESSOPEN


### PR DESCRIPTION
BEGINRELEASENOTES
NEW: add DAVIX_USE_LIBCURL=1 in diracosrc
ENDRELEASENOTES

@chrisburr I wanted to do the same for DIRACOS2, but there is no `diracosrc` equivalent. How should we do ? (without this, we can segfault)