### PR TITLE
Add prompt-toolkit

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -54,6 +54,7 @@ suds-jurko>=0.6
 typing==3.6.6
 hypothesis
 python-json-logger>=0.1.8
+prompt-toolkit
 # Add uproot and optional compression related libraries
 uproot
 backports.lzma


### PR DESCRIPTION
Add prompt-toolkit as an explicit dependency now it is being used in https://github.com/DIRACGrid/DIRAC/pull/5004

BEGINRELEASENOTES

NEW: Add prompt-toolkit 

ENDRELEASENOTES
