### PR TITLE
Add importlib_resources

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -55,6 +55,7 @@ typing==3.6.6
 hypothesis
 python-json-logger>=0.1.8
 prompt-toolkit
+importlib_resources
 # Add uproot and optional compression related libraries
 uproot
 backports.lzma


### PR DESCRIPTION
`importlib_resources` is a backport of Python 3's `importlib.resources` module. It'll be quite useful for my Python 3 PRs in DIRAC to avoid writing `if six.PY3:` everywhere.

BEGINRELEASENOTES

NEW: Add importlib_resources

ENDRELEASENOTES
