### PR TITLE
Freeze to SQLAlchemy 1.3.24

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -45,7 +45,8 @@ readline>=6.2.4
 requests>=2.9.1
 simplejson>=3.8.1
 six>=1.10
-sqlalchemy>=1.0.9
+# Freeze until all problems with 1.4 are solved
+sqlalchemy>=1.3.*
 # More recent version of stomp are python 3 only
 stomp.py==4.1.22
 subprocess32


### PR DESCRIPTION
BEGINRELEASENOTES

CHANGE: Freeze SQLAlchemy to 1.3.24 until the issues with 1.4 are solved

ENDRELEASENOTES
