### PR TITLE
awkward is needed for uproot

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -59,6 +59,7 @@ prompt-toolkit
 importlib_resources
 # Add uproot and optional compression related libraries
 uproot
+awkward
 backports.lzma
 lz4
 xxhash


### PR DESCRIPTION
This dependency was implicit, and we lost it since 1.15

BEGINRELEASENOTES
FIX: explicitly add awkward as a dependency
ENDRELEASENOTES
