### PR TITLE
Use davix 0.7.6

### DIFF
--- a/config/diracos.json
+++ b/config/diracos.json
@@ -472,7 +472,7 @@
             "name": "davix",
             "packages": [
                {
-                  "src": "https://diracos.web.cern.ch/diracos/SRPM/davix-0.7.6.200.3c48eab-1.el6.src.rpm",
+                  "src": "https://storage-ci.web.cern.ch/storage-ci/davix/R_0_7_6/el6/SRPMS/davix-0.7.6-1.el6.src.rpm",
                   "originalRepo": "https://storage-ci.web.cern.ch/storage-ci/davix/",
                   "name": "davix"
                }

--- a/patches/davix.patch
+++ b/patches/davix.patch
@@ -1,24 +1,14 @@
-Only in modified/: davix-0.7.6.200.3c48eab-1.el6.py27.usc4.src.rpm
-diff -r -u original/davix.spec modified/davix.spec
---- original/davix.spec	2020-11-10 03:21:20.000000000 +0000
-+++ modified/davix.spec	2021-01-28 08:09:13.207702045 +0000
-@@ -1,5 +1,5 @@
+diff -u -r original/davix.spec modified/davix.spec
+--- original/davix.spec	2020-04-29 14:09:47.000000000 +0200
++++ modified/davix.spec	2021-07-29 14:27:24.305798955 +0200
+@@ -1,5 +1,6 @@
+ # unversionned doc dir F20 change https://fedoraproject.org/wiki/Changes/UnversionedDocdirs
  %{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
--%global __cmake cmake3
 +%global cmake /usr/bin/cmake
  
  Name:				davix
- Version:			0.7.6.200.3c48eab
-@@ -13,8 +13,6 @@
- #main lib dependencies
- BuildRequires:                  python2
- BuildRequires:                  libuuid-devel
--BuildRequires:                  cmake
--BuildRequires:                  cmake3
- BuildRequires:                  doxygen
- BuildRequires:                  libxml2-devel
- BuildRequires:                  openssl-devel
-@@ -25,10 +23,6 @@
+ Version:			0.7.6
+@@ -24,11 +25,6 @@
  # davix-copy dependencies
  BuildRequires:                  gsoap-devel
  
@@ -26,22 +16,11 @@ diff -r -u original/davix.spec modified/davix.spec
 -%if %{?fedora}%{!?fedora:0} >= 10 || %{?rhel}%{!?rhel:0} >= 6
 -BuildRequires:                  abi-compliance-checker
 -%endif
- 
+-
  Requires:                       %{name}-libs%{?_isa} = %{version}-%{release}
  
-@@ -66,9 +60,9 @@
- with Http based protocols (WebDav, Amazon S3, ...).
  
- %package doc
--Summary:			Documentation for %{name}
-+Summary:                        Documentation for %{name}
- %if %{?fedora}%{!?fedora:0} >= 10 || %{?rhel}%{!?rhel:0} >= 6
--BuildArch:	noarch
-+BuildArch:      noarch
- %endif
- 
- %description doc
-@@ -89,7 +83,7 @@
+@@ -87,7 +83,7 @@
  %cmake \
  -DDOC_INSTALL_DIR=%{_pkgdocdir} \
  -DENABLE_THIRD_PARTY_COPY=TRUE \
@@ -50,12 +29,11 @@ diff -r -u original/davix.spec modified/davix.spec
  .
  make %{?_smp_mflags}
  make doc
-@@ -129,7 +123,7 @@
+@@ -131,7 +127,6 @@
  %files doc
  %{_pkgdocdir}/LICENSE
  %{_pkgdocdir}/RELEASE-NOTES.md
 -%{_pkgdocdir}/html/
-+
  
  %files tests
  %{_bindir}/davix-unit-tests


### PR DESCRIPTION
Being tested here: https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/-/pipelines/2884161
(the test fails because of `asyncio` which is fixed here https://github.com/DIRACGrid/DIRACOS/pull/186

BEGINRELEASENOTES
CHANGE: replace RC by real davix 0.7.6

ENDRELEASENOTES
