### PR TITLE
Release SQLAlchemy constraint

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -46,8 +46,7 @@ requests>=2.9.1
 selectors2
 simplejson>=3.8.1
 six>=1.10
-# Freeze until all problems with 1.4 are solved
-sqlalchemy==1.3.*
+sqlalchemy
 cachetools<4
 # More recent version of stomp are python 3 only
 stomp.py==4.1.22

--- a/tests/integration/test_dyn_import.py
+++ b/tests/integration/test_dyn_import.py
@@ -56,6 +56,7 @@ ALLOWED_TO_FAIL = ['cx_Oracle',  # This is used by some extensions and migration
                    'irods',  # not clear whether someone in DIRAC still uses it
                    'lfcthr',  # used by the LFC plugins
                    'pathlib',  # only used for Python 3 installations
+                   'asyncio',  # only used for Python 3 installations
                    ]
 
 # List of modules that need graphic libraries.


### PR DESCRIPTION
Being tested here: https://gitlab.cern.ch/CLICdp/iLCDirac/diracos-test/-/pipelines/2884196

BEGINRELEASENOTES
CHANGE: release constraint on SQLAlchemy

ENDRELEASENOTES
