### PR TITLE
fixing elasticsearch-py to <7.14

### DIFF
--- a/config/requirements.txt
+++ b/config/requirements.txt
@@ -13,6 +13,7 @@ codecov
 rucio-clients
 diraccfg
 docutils
+elasticsearch <7.14
 elasticsearch-dsl>=6.0.0,<7.0.0
 flaky
 fts3-rest


### PR DESCRIPTION
All in https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/

Already done in https://github.com/DIRACGrid/DIRAC/pull/5322/

BEGINRELEASENOTES

FIX: fixing elasticsearch-py to <7.14 

ENDRELEASENOTES
