### PR TITLE
Use patchelf 0.12 as patchelf 0.13 is segfaulting

### DIFF
--- a/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
+++ b/diracos/scriptTemplates/bundle_diracos_script_tpl.sh
@@ -42,7 +42,7 @@ export CONDA_BASE_TMP=$(mktemp -d)
  bash Miniconda3-py37_4.8.2-Linux-x86_64.sh -b -p "${CONDA_BASE_TMP}/miniconda")
 (source "${CONDA_BASE_TMP}/miniconda/bin/activate" &&
  conda config --add channels conda-forge --env &&
- conda install --yes python-magic patchelf py-lief tqdm &&
+ conda install --yes python-magic patchelf=0.12 py-lief tqdm &&
  python /tmp/set_RPATH.py $DIRACOS)
 rm -rf "${CONDA_BASE_TMP}"
 


### PR DESCRIPTION
Builds have been failing since patchelf 0.13 was released with:

```
subprocess.CalledProcessError: Command '['patchelf', '--force-rpath', '--set-rpath', '', '/tmp/diracos/usr/lib64/libgdbm.so.2.0.0']' died with <Signals.SIGSEGV: 11>.
```

It's only used as part of bundling DIRACOS and I don't think it's worth debugging so I'll just force it to use the previous version.